### PR TITLE
Base: allow to create alignment for individual detectors other than ITS

### DIFF
--- a/Detectors/Base/include/DetectorsBase/GRPGeomHelper.h
+++ b/Detectors/Base/include/DetectorsBase/GRPGeomHelper.h
@@ -98,12 +98,13 @@ struct GRPGeomRequest {
   bool askGRPLHCIF = false;
   bool askGRPMagField = false;
   bool askMatLUT = false;
-  bool askTime = false;       // need orbit reset time for precise timestamp calculation
-  bool askGeomAlign = false;  // load aligned geometry
-  bool askGeomIdeal = false;  // load ideal geometry
-  bool askAlignments = false; // load detector alignments but don't apply them
-  bool askOnceAllButField = false; // for all entries but field query only once
-  bool needPropagatorD = false;    // init also PropagatorD
+  bool askTime = false;                    // need orbit reset time for precise timestamp calculation
+  bool askGeomAlign = false;               // load aligned geometry
+  bool askGeomIdeal = false;               // load ideal geometry
+  bool askAlignments = false;              // load detector alignments but don't apply them
+  bool askOnceAllButField = false;         // for all entries but field query only once
+  bool needPropagatorD = false;            // init also PropagatorD
+  o2::detectors::DetID::mask_t algDetMask; // mask of requested alignment objects
 
   GRPGeomRequest() = delete;
   GRPGeomRequest(bool orbitResetTime, bool GRPECS, bool GRPLHCIF, bool GRPMagField, bool askMatLUT, GeomRequest geom, std::vector<o2::framework::InputSpec>& inputs, bool askOnce = false, bool needPropD = false, std::string detMaskString = "all");

--- a/Detectors/Base/src/GRPGeomHelper.cxx
+++ b/Detectors/Base/src/GRPGeomHelper.cxx
@@ -37,7 +37,7 @@ using namespace o2::framework;
 namespace o2d = o2::dataformats;
 
 GRPGeomRequest::GRPGeomRequest(bool orbitResetTime, bool GRPECS, bool GRPLHCIF, bool GRPMagField, bool askMatLUT, GeomRequest geom, std::vector<o2::framework::InputSpec>& inputs, bool askOnce, bool needPropD, std::string detMaskString)
-  : askGRPECS(GRPECS), askGRPLHCIF(GRPLHCIF), askGRPMagField(GRPMagField), askMatLUT(askMatLUT), askTime(orbitResetTime), askOnceAllButField(askOnce), needPropagatorD(needPropD)
+  : askGRPECS(GRPECS), askGRPLHCIF(GRPLHCIF), askGRPMagField(GRPMagField), askMatLUT(askMatLUT), askTime(orbitResetTime), askOnceAllButField(askOnce), needPropagatorD(needPropD), algDetMask(DetID::getMask(detMaskString))
 {
   if (geom == Aligned) {
     askGeomAlign = true;
@@ -48,7 +48,6 @@ GRPGeomRequest::GRPGeomRequest(bool orbitResetTime, bool GRPECS, bool GRPLHCIF, 
   }
   if (geom == Alignments) {
     askAlignments = true;
-    o2::detectors::DetID::mask_t algDetMask = DetID::getMask(detMaskString);
     for (auto id = DetID::First; id <= DetID::Last; id++) {
       if (algDetMask[id]) {
         std::string binding = fmt::format("align{}", DetID::getName(id));
@@ -164,6 +163,9 @@ bool GRPGeomHelper::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
   constexpr o2::header::DataDescription algDesc{"ALIGNMENT"};
   if (mRequest->askAlignments && matcher.description == algDesc) {
     for (auto id = DetID::First; id <= DetID::Last; id++) {
+      if (!mRequest->algDetMask[id]) {
+        continue;
+      }
       if (matcher.origin == DetID::getDataOrigin(id)) {
         LOG(info) << DetID::getName(id) << " alignment updated";
         mAlignments[id] = (std::vector<o2::detectors::AlignParam>*)obj;
@@ -233,9 +235,12 @@ void GRPGeomHelper::checkUpdates(ProcessingContext& pc)
     }
     if (mRequest->askAlignments) {
       for (auto id = DetID::First; id <= DetID::Last; id++) {
+        if (!mRequest->algDetMask[id]) {
+          continue;
+        }
         std::string binding = fmt::format("align{}", DetID::getName(id));
         if (pc.inputs().getPos(binding.c_str()) < 0) {
-          return;
+          LOGP(fatal, "Alignment for detector {} was requested but no binding was found!", id);
         } else {
           pc.inputs().get<std::vector<o2::detectors::AlignParam>*>(binding);
         }


### PR DESCRIPTION
Allows to request alignment to be created for IT3 with '--onlyDet IT3'.
The matcher always exited if there was no binding for ITS, so any other detector with lower ordering would not be aligned. But ok probably no alignment was ever requested without ITS :)

Signed-off-by: Felix Schlepper <felix.schlepper@cern.ch>