### PR TITLE
Adapt ITS/MFT CTF machinery to staggered data

### DIFF
--- a/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
+++ b/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
@@ -34,7 +34,7 @@
 #include "ReconstructionDataFormats/TrackMCHMID.h"
 #include "DataFormatsITSMFT/TrkClusRef.h"
 #include "DataFormatsITSMFT/TopologyDictionary.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 // FIXME: ideally, the data formats definition should be independent of the framework
 // collectData is using the input of ProcessingContext to extract the first valid
 // header and the TF orbit from it

--- a/DataFormats/Detectors/ITSMFT/common/CMakeLists.txt
+++ b/DataFormats/Detectors/ITSMFT/common/CMakeLists.txt
@@ -20,13 +20,17 @@ o2_add_library(DataFormatsITSMFT
                        src/TopologyDictionary.cxx
                        src/TimeDeadMap.cxx
                        src/CTF.cxx
+                       src/DPLAlpideParam.cxx
                PUBLIC_LINK_LIBRARIES O2::ITSMFTBase
+                       O2::DetectorsCommonDataFormats
                        O2::ReconstructionDataFormats
+                       O2::CommonUtils
                        Microsoft.GSL::GSL)
 
 o2_target_root_dictionary(DataFormatsITSMFT
                           HEADERS include/DataFormatsITSMFT/ROFRecord.h
                                   include/DataFormatsITSMFT/Digit.h
+                                  include/DataFormatsITSMFT/DPLAlpideParam.h
                                   include/DataFormatsITSMFT/GBTCalibData.h
                                   include/DataFormatsITSMFT/NoiseMap.h
                                   include/DataFormatsITSMFT/TimeDeadMap.h

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/CTF.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/CTF.h
@@ -36,7 +36,9 @@ struct CTFHeader : public o2::ctf::CTFDictHeader {
   uint32_t nPatternBytes = 0; /// number of bytes for explict patterns
   uint32_t firstOrbit = 0;    /// 1st orbit of TF
   uint16_t firstBC = 0;       /// 1st BC of TF
-  ClassDefNV(CTFHeader, 2);
+  uint8_t maxStreams = 1;     /// Number of streams per TF (== NLayers for staggered ITS/MFT readout, 1 for non-staggered one)
+  uint8_t streamID = 0;       /// ID of the stream (0:maxStreams-1)
+  ClassDefNV(CTFHeader, 3);
 };
 
 /// Compressed but not yet entropy-encoded clusters

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/DPLAlpideParam.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/DPLAlpideParam.h
@@ -9,8 +9,8 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifndef ALICEO2_ITSMFTDPLBASEPARAM_H_
-#define ALICEO2_ITSMFTDPLBASEPARAM_H_
+#ifndef ALICEO2_ITSMFTALPIDEPARAM_H_
+#define ALICEO2_ITSMFTALPIDEPARAM_H_
 
 #include "DetectorsCommonDataFormats/DetID.h"
 #include "CommonUtils/ConfigurableParam.h"

--- a/DataFormats/Detectors/ITSMFT/common/src/DPLAlpideParam.cxx
+++ b/DataFormats/Detectors/ITSMFT/common/src/DPLAlpideParam.cxx
@@ -9,7 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 
 namespace o2
 {

--- a/DataFormats/Detectors/ITSMFT/common/src/ITSMFTDataFormatsLinkDef.h
+++ b/DataFormats/Detectors/ITSMFT/common/src/ITSMFTDataFormatsLinkDef.h
@@ -15,6 +15,11 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
+#pragma link C++ class o2::itsmft::DPLAlpideParam < o2::detectors::DetID::ITS> + ;
+#pragma link C++ class o2::itsmft::DPLAlpideParam < o2::detectors::DetID::MFT> + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::itsmft::DPLAlpideParam < o2::detectors::DetID::ITS>> + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::itsmft::DPLAlpideParam < o2::detectors::DetID::MFT>> + ;
+
 #pragma link C++ class o2::itsmft::Digit + ;
 #pragma link C++ class o2::itsmft::NoiseMap + ;
 #pragma link C++ class o2::itsmft::TimeDeadMap + ;

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -60,7 +60,7 @@
 #include "GlobalTracking/MatchGlobalFwd.h"
 #include "MCHTracking/TrackExtrap.h"
 #include "MCHTracking/TrackParam.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "DetectorsVertexing/PVertexerParams.h"
 #include "ReconstructionDataFormats/GlobalFwdTrack.h"
 #include "ReconstructionDataFormats/GlobalTrackID.h"

--- a/Detectors/Align/Workflow/src/BarrelAlignmentSpec.cxx
+++ b/Detectors/Align/Workflow/src/BarrelAlignmentSpec.cxx
@@ -64,7 +64,7 @@
 #include "DataFormatsTPC/ClusterNative.h"
 #include "DataFormatsTPC/WorkflowHelper.h"
 #include "ITSBase/GeometryTGeo.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 */
 
 using namespace o2::framework;

--- a/Detectors/CTF/test/test_ctf_io_itsmft.cxx
+++ b/Detectors/CTF/test/test_ctf_io_itsmft.cxx
@@ -81,7 +81,7 @@ BOOST_DATA_TEST_CASE(CompressedClustersTest, boost_data::make(ANSVersions), ansV
   sw.Start();
   std::vector<o2::ctf::BufferType> vec;
   {
-    CTFCoder coder(o2::ctf::CTFCoderBase::OpType::Encoder, o2::detectors::DetID::ITS);
+    CTFCoder<o2::detectors::DetID::ITS> coder(o2::ctf::CTFCoderBase::OpType::Encoder);
     coder.setANSVersion(ansVersion);
     coder.encode(vec, rofRecVec, cclusVec, pattVec, pattIdConverter, 0); // compress
   }
@@ -120,7 +120,7 @@ BOOST_DATA_TEST_CASE(CompressedClustersTest, boost_data::make(ANSVersions), ansV
   sw.Start();
   const auto ctfImage = o2::itsmft::CTF::getImage(vec.data());
   {
-    CTFCoder coder(o2::ctf::CTFCoderBase::OpType::Decoder, o2::detectors::DetID::ITS);
+    CTFCoder<o2::detectors::DetID::ITS> coder(o2::ctf::CTFCoderBase::OpType::Decoder);
     coder.decode(ctfImage, rofRecVecD, cclusVecD, pattVecD, nullptr, clPattLookup); // decompress
   }
   sw.Stop();

--- a/Detectors/CTF/workflow/src/CTFReaderSpec.cxx
+++ b/Detectors/CTF/workflow/src/CTFReaderSpec.cxx
@@ -35,6 +35,7 @@
 #include "CommonUtils/NameConf.h"
 #include "DetectorsCommonDataFormats/CTFHeader.h"
 #include "Headers/STFHeader.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "DataFormatsITSMFT/CTF.h"
 #include "DataFormatsTPC/CTF.h"
 #include "DataFormatsTRD/CTF.h"
@@ -185,6 +186,50 @@ void CTFReaderSpec::init(InitContext& ic)
   if (!mInput.fileRunTimeSpans.empty()) {
     loadRunTimeSpans(mInput.fileRunTimeSpans);
     mIFRamesOut = true;
+  }
+}
+
+///_______________________________________
+template <>
+void CTFReaderSpec::processDetector<o2::itsmft::CTF>(DetID det, const CTFHeader& ctfHeader, ProcessingContext& pc) const
+{
+  if (mInput.detMask[det]) {
+    std::string lbl = det.getName();
+    int nLayers = 1;
+    if (det == DetID::ITS) {
+      const auto& par = o2::itsmft::DPLAlpideParam<DetID::ITS>::Instance();
+      nLayers = par.supportsStaggering() ? par.getNLayers() : 1;
+    } else if (det == DetID::MFT) {
+      const auto& par = o2::itsmft::DPLAlpideParam<DetID::MFT>::Instance();
+      nLayers = par.supportsStaggering() ? par.getNLayers() : 1;
+    } else {
+      LOGP(fatal, "This specialization is define only for ITS and MFT detectors, {} provided", det.getName());
+    }
+    for (int iLayer = 0; iLayer < nLayers; iLayer++) {
+      auto& bufVec = pc.outputs().make<std::vector<o2::ctf::BufferType>>({lbl, mInput.subspec * 100 + iLayer}, ctfHeader.detectors[det] ? sizeof(o2::itsmft::CTF) : 0);
+      if (ctfHeader.detectors[det]) {
+        auto brName = nLayers == 1 ? lbl : fmt::format("{}_{}", lbl, iLayer);
+        o2::itsmft::CTF::readFromTree(bufVec, *(mCTFTree.get()), brName, mCurrTreeEntry);
+      } else if (!mInput.allowMissingDetectors) {
+        throw std::runtime_error(fmt::format("Requested detector {} is missing in the CTF", lbl));
+      }
+    }
+  }
+}
+
+///_______________________________________
+template <typename C>
+void CTFReaderSpec::processDetector(DetID det, const CTFHeader& ctfHeader, ProcessingContext& pc) const
+{
+  if (mInput.detMask[det]) {
+    const auto lbl = det.getName();
+    auto& bufVec = pc.outputs().make<std::vector<o2::ctf::BufferType>>({lbl, mInput.subspec}, ctfHeader.detectors[det] ? sizeof(C) : 0);
+    if (ctfHeader.detectors[det]) {
+      C::readFromTree(bufVec, *(mCTFTree.get()), lbl, mCurrTreeEntry);
+    } else if (!mInput.allowMissingDetectors) {
+      throw std::runtime_error(fmt::format("Requested detector {} is missing in the CTF", lbl));
+    }
+    //    setMessageHeader(pc, ctfHeader, lbl);
   }
 }
 
@@ -563,22 +608,6 @@ void CTFReaderSpec::setMessageHeader(ProcessingContext& pc, const CTFHeader& ctf
 }
 
 ///_______________________________________
-template <typename C>
-void CTFReaderSpec::processDetector(DetID det, const CTFHeader& ctfHeader, ProcessingContext& pc) const
-{
-  if (mInput.detMask[det]) {
-    const auto lbl = det.getName();
-    auto& bufVec = pc.outputs().make<std::vector<o2::ctf::BufferType>>({lbl, mInput.subspec}, ctfHeader.detectors[det] ? sizeof(C) : 0);
-    if (ctfHeader.detectors[det]) {
-      C::readFromTree(bufVec, *(mCTFTree.get()), lbl, mCurrTreeEntry);
-    } else if (!mInput.allowMissingDetectors) {
-      throw std::runtime_error(fmt::format("Requested detector {} is missing in the CTF", lbl));
-    }
-    //    setMessageHeader(pc, ctfHeader, lbl);
-  }
-}
-
-///_______________________________________
 void CTFReaderSpec::tryToFixCTFHeader(CTFHeader& ctfHeader) const
 {
   // HACK: fix CTFHeader for the pilot beam runs, where the TF creation time was not recorded
@@ -636,7 +665,21 @@ DataProcessorSpec getCTFReaderSpec(const CTFReaderInp& inp)
   for (auto id = DetID::First; id <= DetID::Last; id++) {
     if (inp.detMask[id]) {
       DetID det(id);
-      outputs.emplace_back(OutputLabel{det.getName()}, det.getDataOrigin(), "CTFDATA", inp.subspec, Lifetime::Timeframe);
+      if (det == DetID::ITS) {
+        const auto& par = o2::itsmft::DPLAlpideParam<DetID::ITS>::Instance();
+        uint32_t nLayers = par.supportsStaggering() ? par.getNLayers() : 1;
+        for (uint32_t iLayer = 0; iLayer < nLayers; iLayer++) {
+          outputs.emplace_back(OutputLabel{det.getName()}, det.getDataOrigin(), "CTFDATA", inp.subspec * 100 + iLayer, Lifetime::Timeframe);
+        }
+      } else if (det == DetID::MFT) {
+        const auto& par = o2::itsmft::DPLAlpideParam<DetID::MFT>::Instance();
+        uint32_t nLayers = par.supportsStaggering() ? par.getNLayers() : 1;
+        for (uint32_t iLayer = 0; iLayer < nLayers; iLayer++) {
+          outputs.emplace_back(OutputLabel{det.getName()}, det.getDataOrigin(), "CTFDATA", inp.subspec * 100 + iLayer, Lifetime::Timeframe);
+        }
+      } else {
+        outputs.emplace_back(OutputLabel{det.getName()}, det.getDataOrigin(), "CTFDATA", inp.subspec, Lifetime::Timeframe);
+      }
     }
   }
   if (!inp.fileIRFrames.empty() || !inp.fileRunTimeSpans.empty()) {

--- a/Detectors/CTF/workflow/src/CTFWriterSpec.cxx
+++ b/Detectors/CTF/workflow/src/CTFWriterSpec.cxx
@@ -29,6 +29,7 @@
 #include "DetectorsCommonDataFormats/EncodedBlocks.h"
 #include "DetectorsCommonDataFormats/FileMetaData.h"
 #include "CommonUtils/StringUtils.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "DataFormatsITSMFT/CTF.h"
 #include "DataFormatsTPC/CTF.h"
 #include "DataFormatsTRD/CTF.h"
@@ -105,6 +106,8 @@ class CTFWriterSpec : public o2::framework::Task
   void endOfStream(o2::framework::EndOfStreamContext& ec) final { finalize(); }
   void stop() final { finalize(); }
   bool isPresent(DetID id) const { return mDets[id]; }
+
+  static std::string getBinding(const std::string& name, int spec) { return fmt::format("{}_{}", name, spec); }
 
  private:
   void updateTimeDependentParams(ProcessingContext& pc);
@@ -301,71 +304,84 @@ size_t CTFWriterSpec::processDet(o2::framework::ProcessingContext& pc, DetID det
 {
   static bool warnedEmpty = false;
   size_t sz = 0;
-  if (!isPresent(det) || !pc.inputs().isValid(det.getName())) {
+
+  if (!isPresent(det) || !pc.inputs().isValid(getBinding(det.getName(), 0))) {
     mSizeReport += fmt::format(" {}:N/A", det.getName());
     return sz;
   }
-  auto ctfBuffer = pc.inputs().get<gsl::span<o2::ctf::BufferType>>(det.getName());
-  const o2::ctf::BufferType* bdata = ctfBuffer.data();
-  if (bdata) {
-    if (warnedEmpty) {
-      throw std::runtime_error(fmt::format("Non-empty input was seen at {}-th TF after empty one for {}, this will lead to misalignment of detectors in CTF", mNCTF, det.getName()));
-    }
-    const auto ctfImage = C::getImage(bdata);
-    ctfImage.print(o2::utils::Str::concat_string(det.getName(), ": "), mVerbosity);
-    if (mWriteCTF && !mRejectCurrentTF) {
-      sz = ctfImage.appendToTree(*tree, det.getName());
-      header.detectors.set(det);
-    } else {
-      sz = ctfBuffer.size();
-    }
-    if (mCreateDict) {
-      if (mFreqsAccumulation[det].empty()) {
-        mFreqsAccumulation[det].resize(C::getNBlocks());
-        mFreqsMetaData[det].resize(C::getNBlocks());
+
+  uint32_t nLayers = 1;
+  if (det == DetID::ITS) {
+    const auto& par = o2::itsmft::DPLAlpideParam<DetID::ITS>::Instance();
+    nLayers = par.supportsStaggering() ? par.getNLayers() : 1;
+  } else if (det == DetID::MFT) {
+    const auto& par = o2::itsmft::DPLAlpideParam<DetID::MFT>::Instance();
+    nLayers = par.supportsStaggering() ? par.getNLayers() : 1;
+  }
+  for (uint32_t iLayer = 0; iLayer < nLayers; iLayer++) {
+    auto binding = getBinding(det.getName(), iLayer);
+    auto ctfBuffer = pc.inputs().get<gsl::span<o2::ctf::BufferType>>(binding);
+    const o2::ctf::BufferType* bdata = ctfBuffer.data();
+    if (bdata) {
+      if (warnedEmpty) {
+        throw std::runtime_error(fmt::format("Non-empty input was seen at {}-th TF after empty one for {}, this will lead to misalignment of detectors in CTF", mNCTF, det.getName()));
       }
-      if (!mHeaders[det]) { // store 1st header
-        mHeaders[det] = ctfImage.cloneHeader();
-        auto& hb = *static_cast<o2::ctf::CTFDictHeader*>(mHeaders[det].get());
-        hb.det = det;
+      const auto ctfImage = C::getImage(bdata);
+      ctfImage.print(o2::utils::Str::concat_string(binding, ": "), mVerbosity);
+      if (mWriteCTF && !mRejectCurrentTF) {
+        sz += ctfImage.appendToTree(*tree, nLayers > 1 ? binding : det.getName());
+        header.detectors.set(det);
+      } else {
+        sz += ctfBuffer.size();
       }
-      for (int ib = 0; ib < C::getNBlocks(); ib++) {
-        if (!mIsSaturatedFrequencyTable[det][ib]) {
-          const auto& bl = ctfImage.getBlock(ib);
-          if (bl.getNDict()) {
-            auto freq = mFreqsAccumulation[det][ib];
-            auto& mdSave = mFreqsMetaData[det][ib];
-            const auto& md = ctfImage.getMetadata(ib);
-            if ([&, this]() {
-                  try {
-                    freq.addFrequencies(bl.getDict(), bl.getDict() + bl.getNDict(), md.min);
-                  } catch (const std::overflow_error& e) {
-                    LOGP(warning, "unable to add frequency table for {}, block {} due to overflow", det.getName(), ib);
-                    mIsSaturatedFrequencyTable[det][ib] = true;
-                    return false;
-                  }
-                  return true;
-                }()) {
-              auto newProbBits = static_cast<uint8_t>(o2::rans::compat::computeRenormingPrecision(countNUsedAlphabetSymbols(freq)));
-              auto histogramView = o2::rans::trim(o2::rans::makeHistogramView(freq));
-              mdSave = ctf::detail::makeMetadataRansDict(newProbBits,
-                                                         static_cast<int32_t>(histogramView.getMin()),
-                                                         static_cast<int32_t>(histogramView.getMax()),
-                                                         static_cast<int32_t>(histogramView.size()),
-                                                         md.opt);
-              mFreqsAccumulation[det][ib] = std::move(freq);
+      if (mCreateDict) { // RSTODO
+        if (mFreqsAccumulation[det].empty()) {
+          mFreqsAccumulation[det].resize(C::getNBlocks());
+          mFreqsMetaData[det].resize(C::getNBlocks());
+        }
+        if (!mHeaders[det]) { // store 1st header
+          mHeaders[det] = ctfImage.cloneHeader();
+          auto& hb = *static_cast<o2::ctf::CTFDictHeader*>(mHeaders[det].get());
+          hb.det = det;
+        }
+        for (int ib = 0; ib < C::getNBlocks(); ib++) {
+          if (!mIsSaturatedFrequencyTable[det][ib]) {
+            const auto& bl = ctfImage.getBlock(ib);
+            if (bl.getNDict()) {
+              auto freq = mFreqsAccumulation[det][ib];
+              auto& mdSave = mFreqsMetaData[det][ib];
+              const auto& md = ctfImage.getMetadata(ib);
+              if ([&, this]() {
+                    try {
+                      freq.addFrequencies(bl.getDict(), bl.getDict() + bl.getNDict(), md.min);
+                    } catch (const std::overflow_error& e) {
+                      LOGP(warning, "unable to add frequency table for {}, block {} due to overflow", det.getName(), ib);
+                      mIsSaturatedFrequencyTable[det][ib] = true;
+                      return false;
+                    }
+                    return true;
+                  }()) {
+                auto newProbBits = static_cast<uint8_t>(o2::rans::compat::computeRenormingPrecision(countNUsedAlphabetSymbols(freq)));
+                auto histogramView = o2::rans::trim(o2::rans::makeHistogramView(freq));
+                mdSave = ctf::detail::makeMetadataRansDict(newProbBits,
+                                                           static_cast<int32_t>(histogramView.getMin()),
+                                                           static_cast<int32_t>(histogramView.getMax()),
+                                                           static_cast<int32_t>(histogramView.size()),
+                                                           md.opt);
+                mFreqsAccumulation[det][ib] = std::move(freq);
+              }
             }
           }
         }
       }
-    }
-  } else {
-    if (!warnedEmpty) {
-      if (mNCTF) {
-        throw std::runtime_error(fmt::format("Empty input was seen at {}-th TF after non-empty one for {}, this will lead to misalignment of detectors in CTF", mNCTF, det.getName()));
+    } else {
+      if (!warnedEmpty) {
+        if (mNCTF) {
+          throw std::runtime_error(fmt::format("Empty input was seen at {}-th TF after non-empty one for {}, this will lead to misalignment of detectors in CTF", mNCTF, det.getName()));
+        }
+        LOGP(important, "Empty CTF provided for {}, skipping and will not report anymore", det.getName());
+        warnedEmpty = true;
       }
-      LOGP(important, "Empty CTF provided for {}, skipping and will not report anymore", det.getName());
-      warnedEmpty = true;
     }
   }
   mSizeReport += fmt::format(" {}:{}", det.getName(), fmt::group_digits(sz));
@@ -417,10 +433,21 @@ size_t CTFWriterSpec::estimateCTFSize(ProcessingContext& pc)
   size_t s = 0;
   for (auto id = DetID::First; id <= DetID::Last; id++) {
     DetID det(id);
-    if (!isPresent(det) || !pc.inputs().isValid(det.getName())) {
-      continue;
+    uint32_t nLayers = 1;
+    if (det == DetID::ITS) {
+      const auto& par = o2::itsmft::DPLAlpideParam<DetID::ITS>::Instance();
+      nLayers = par.supportsStaggering() ? par.getNLayers() : 1;
+    } else if (det == DetID::MFT) {
+      const auto& par = o2::itsmft::DPLAlpideParam<DetID::MFT>::Instance();
+      nLayers = par.supportsStaggering() ? par.getNLayers() : 1;
     }
-    s += pc.inputs().get<gsl::span<o2::ctf::BufferType>>(det.getName()).size();
+    for (uint32_t iLayer = 0; iLayer < nLayers; iLayer++) {
+      auto binding = getBinding(det.getName(), iLayer);
+      if (!isPresent(det) || !pc.inputs().isValid(binding)) {
+        continue;
+      }
+      s += pc.inputs().get<gsl::span<o2::ctf::BufferType>>(binding).size();
+    }
   }
   return s;
 }
@@ -794,7 +821,18 @@ DataProcessorSpec getCTFWriterSpec(DetID::mask_t dets, const std::string& outTyp
   LOG(debug) << "Detectors list:";
   for (auto id = DetID::First; id <= DetID::Last; id++) {
     if (dets[id]) {
-      inputs.emplace_back(DetID::getName(id), DetID::getDataOrigin(id), "CTFDATA", 0, Lifetime::Timeframe);
+      uint32_t nLayers = 1;
+      DetID det{id};
+      if (det == DetID::ITS) {
+        const auto& par = o2::itsmft::DPLAlpideParam<DetID::ITS>::Instance();
+        nLayers = par.supportsStaggering() ? par.getNLayers() : 1;
+      } else if (det == DetID::MFT) {
+        const auto& par = o2::itsmft::DPLAlpideParam<DetID::MFT>::Instance();
+        nLayers = par.supportsStaggering() ? par.getNLayers() : 1;
+      }
+      for (uint32_t iLayer = 0; iLayer < nLayers; iLayer++) {
+        inputs.emplace_back(CTFWriterSpec::getBinding(det.getName(), iLayer), det.getDataOrigin(), "CTFDATA", iLayer, Lifetime::Timeframe);
+      }
       LOG(debug) << "Det " << DetID::getName(id) << " added";
     }
   }

--- a/Detectors/CTF/workflow/src/ctf-reader-workflow.cxx
+++ b/Detectors/CTF/workflow/src/ctf-reader-workflow.cxx
@@ -183,10 +183,10 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 
   // add decoders for all allowed detectors.
   if (ctfInput.detMask[DetID::ITS]) {
-    addSpecs(o2::itsmft::getEntropyDecoderSpec(DetID::getDataOrigin(DetID::ITS), verbosity, configcontext.options().get<bool>("its-digits"), ctfInput.subspec, ctfInput.dictOpt));
+    addSpecs(o2::itsmft::getITSEntropyDecoderSpec(verbosity, configcontext.options().get<bool>("its-digits"), ctfInput.subspec, ctfInput.dictOpt));
   }
   if (ctfInput.detMask[DetID::MFT]) {
-    addSpecs(o2::itsmft::getEntropyDecoderSpec(DetID::getDataOrigin(DetID::MFT), verbosity, configcontext.options().get<bool>("mft-digits"), ctfInput.subspec, ctfInput.dictOpt));
+    addSpecs(o2::itsmft::getMFTEntropyDecoderSpec(verbosity, configcontext.options().get<bool>("mft-digits"), ctfInput.subspec, ctfInput.dictOpt));
   }
   if (ctfInput.detMask[DetID::TPC]) {
     addSpecs(o2::tpc::getEntropyDecoderSpec(verbosity, ctfInput.subspec, ctfInput.dictOpt));

--- a/Detectors/Filtering/src/FilteringSpec.cxx
+++ b/Detectors/Filtering/src/FilteringSpec.cxx
@@ -46,7 +46,7 @@
 #include "ReconstructionDataFormats/Cascade.h"
 #include "MCHTracking/TrackExtrap.h"
 #include "MCHTracking/TrackParam.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "DetectorsVertexing/PVertexerParams.h"
 #include "ReconstructionDataFormats/GlobalTrackID.h"
 #include "ReconstructionDataFormats/Track.h"

--- a/Detectors/GlobalTrackingWorkflow/src/CosmicsMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/CosmicsMatchingSpec.cxx
@@ -40,7 +40,7 @@
 #include "Headers/DataHeader.h"
 #include "CommonDataFormat/InteractionRecord.h"
 #include "ITSBase/GeometryTGeo.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "DataFormatsGlobalTracking/RecoContainer.h"
 #include "Framework/Task.h"
 #include "Framework/CCDBParamSpec.h"

--- a/Detectors/GlobalTrackingWorkflow/src/GlobalFwdMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/GlobalFwdMatchingSpec.cxx
@@ -20,7 +20,7 @@
 #include "Framework/CCDBParamSpec.h"
 #include "CommonUtils/StringUtils.h"
 #include "DetectorsCommonDataFormats/DetectorNameConf.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "DataFormatsMFT/TrackMFT.h"
 #include "DataFormatsITSMFT/Cluster.h"

--- a/Detectors/GlobalTrackingWorkflow/src/PrimaryVertexingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/PrimaryVertexingSpec.cxx
@@ -30,7 +30,7 @@
 #include "Framework/CCDBParamSpec.h"
 #include "Framework/DeviceSpec.h"
 #include "FT0Reconstruction/InteractionTag.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 #include "DetectorsVertexing/PVertexer.h"
 #include "DetectorsBase/GRPGeomHelper.h"

--- a/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
@@ -39,7 +39,7 @@
 #include "DetectorsBase/GeometryManager.h"
 #include "DetectorsBase/Propagator.h"
 #include "DetectorsBase/GlobalParams.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "ITSBase/GeometryTGeo.h"
 #include "GlobalTracking/MatchTPCITSParams.h"
 #include "DetectorsCommonDataFormats/DetectorNameConf.h"

--- a/Detectors/GlobalTrackingWorkflow/src/VertexTrackMatcherSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/VertexTrackMatcherSpec.cxx
@@ -23,7 +23,7 @@
 #include "TPCBase/ParameterElectronics.h"
 #include "TPCBase/ParameterDetector.h"
 #include "TPCCalibration/VDriftHelper.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "TStopwatch.h"
 
 using namespace o2::framework;

--- a/Detectors/GlobalTrackingWorkflow/study/src/CheckResid.cxx
+++ b/Detectors/GlobalTrackingWorkflow/study/src/CheckResid.cxx
@@ -29,7 +29,7 @@
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/CCDBParamSpec.h"
 #include "Framework/DeviceSpec.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "ITSBase/GeometryTGeo.h"
 #include "ITStracking/IOUtils.h"
 #include "DetectorsCommonDataFormats/DetID.h"

--- a/Detectors/GlobalTrackingWorkflow/study/src/DumpTracks.cxx
+++ b/Detectors/GlobalTrackingWorkflow/study/src/DumpTracks.cxx
@@ -21,7 +21,7 @@
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/CCDBParamSpec.h"
 #include "FT0Reconstruction/InteractionTag.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 #include "DetectorsBase/GRPGeomHelper.h"
 #include "GlobalTrackingStudy/TrackingStudy.h"

--- a/Detectors/GlobalTrackingWorkflow/study/src/SVStudy.cxx
+++ b/Detectors/GlobalTrackingWorkflow/study/src/SVStudy.cxx
@@ -29,7 +29,7 @@
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/CCDBParamSpec.h"
 #include "FT0Reconstruction/InteractionTag.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 #include "DetectorsBase/GRPGeomHelper.h"
 #include "GlobalTrackingStudy/TrackingStudy.h"

--- a/Detectors/GlobalTrackingWorkflow/study/src/TrackMCStudy.cxx
+++ b/Detectors/GlobalTrackingWorkflow/study/src/TrackMCStudy.cxx
@@ -34,7 +34,7 @@
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/CCDBParamSpec.h"
 #include "FT0Reconstruction/InteractionTag.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 #include "DetectorsBase/GRPGeomHelper.h"
 #include "GlobalTrackingStudy/TrackMCStudy.h"

--- a/Detectors/GlobalTrackingWorkflow/study/src/TrackingStudy.cxx
+++ b/Detectors/GlobalTrackingWorkflow/study/src/TrackingStudy.cxx
@@ -28,7 +28,7 @@
 #include "Framework/CCDBParamSpec.h"
 #include "Framework/DeviceSpec.h"
 #include "FT0Reconstruction/InteractionTag.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 #include "DetectorsBase/GRPGeomHelper.h"
 #include "GlobalTrackingStudy/TrackingStudy.h"

--- a/Detectors/ITSMFT/ITS/postprocessing/studies/src/ImpactParameter.cxx
+++ b/Detectors/ITSMFT/ITS/postprocessing/studies/src/ImpactParameter.cxx
@@ -29,7 +29,7 @@
 #include "CommonUtils/TreeStreamRedirector.h"
 #include "DetectorsBase/GRPGeomHelper.h"
 #include "DataFormatsParameters/GRPECSObject.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 #include "Framework/DeviceSpec.h"
 #include "CommonUtils/ConfigurableParam.h"

--- a/Detectors/ITSMFT/ITS/reconstruction/src/FastMultEst.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/FastMultEst.cxx
@@ -14,7 +14,7 @@
 /// \author ruben.shahoyan@cern.ch
 
 #include "ITSReconstruction/FastMultEst.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "Framework/Logger.h"
 #include <ctime>
 #include <cstring>

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackingInterface.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackingInterface.cxx
@@ -13,7 +13,7 @@
 
 #include <oneapi/tbb/task_arena.h>
 
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "ITSBase/GeometryTGeo.h"
 
 #include "ITSReconstruction/FastMultEstConfig.h"

--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -25,7 +25,7 @@
 #include "ITStracking/Tracklet.h"
 #include "SimulationDataFormat/DigitizationContext.h"
 #include "Steer/MCKinematicsReader.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "DetectorsRaw/HBFUtils.h"
 
 namespace o2::its

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DCSAdaposParserSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DCSAdaposParserSpec.h
@@ -37,7 +37,7 @@
 #include "DetectorsDCS/DataPointIdentifier.h"
 #include "DetectorsDCS/DataPointValue.h"
 #include "DetectorsDCS/DataPointCompositeObject.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "CCDB/BasicCCDBManager.h"
 
 using namespace o2::framework;

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -15,7 +15,7 @@
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/CCDBParamSpec.h"
 #include "Framework/DeviceSpec.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "ITSWorkflow/TrackerSpec.h"
 #include "ITStracking/Definitions.h"
 #include "ITStracking/TrackingConfigParam.h"

--- a/Detectors/ITSMFT/MFT/calibration/src/NoiseCalibratorSpec.cxx
+++ b/Detectors/ITSMFT/MFT/calibration/src/NoiseCalibratorSpec.cxx
@@ -18,7 +18,7 @@
 #include "DataFormatsITSMFT/Digit.h"
 #include "DataFormatsITSMFT/CompCluster.h"
 #include "DataFormatsITSMFT/ROFRecord.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "ITSMFTReconstruction/ClustererParam.h"
 
 #include <fairlogger/Logger.h>

--- a/Detectors/ITSMFT/MFT/condition/include/MFTCondition/DCSConfigReader.h
+++ b/Detectors/ITSMFT/MFT/condition/include/MFTCondition/DCSConfigReader.h
@@ -14,7 +14,7 @@
 
 #include "Rtypes.h"
 #include "DataFormatsITSMFT/NoiseMap.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "MFTCondition/DCSConfigInfo.h"
 #include "MFTCondition/DCSConfigUtils.h"
 #include <gsl/span>

--- a/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/TrackerSpec.h
+++ b/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/TrackerSpec.h
@@ -16,7 +16,7 @@
 
 #include "MFTTracking/Tracker.h"
 #include "DetectorsBase/GRPGeomHelper.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 
 #include "Framework/DataProcessorSpec.h"
 #include "MFTTracking/TrackCA.h"

--- a/Detectors/ITSMFT/common/base/CMakeLists.txt
+++ b/Detectors/ITSMFT/common/base/CMakeLists.txt
@@ -11,12 +11,10 @@
 
 o2_add_library(ITSMFTBase
                SOURCES src/SegmentationAlpide.cxx
-                       src/GeometryTGeo.cxx src/DPLAlpideParam.cxx
                PUBLIC_LINK_LIBRARIES O2::MathUtils
                                      O2::DetectorsCommonDataFormats
                                      O2::SimConfig)
 
 o2_target_root_dictionary(ITSMFTBase
                           HEADERS include/ITSMFTBase/SegmentationAlpide.h
-                                  include/ITSMFTBase/GeometryTGeo.h
-                                  include/ITSMFTBase/DPLAlpideParam.h)
+                                  include/ITSMFTBase/GeometryTGeo.h)

--- a/Detectors/ITSMFT/common/base/src/ITSMFTBaseLinkDef.h
+++ b/Detectors/ITSMFT/common/base/src/ITSMFTBaseLinkDef.h
@@ -17,11 +17,6 @@
 
 #pragma link C++ class o2::itsmft::SegmentationAlpide + ;
 
-#pragma link C++ class o2::itsmft::DPLAlpideParam < o2::detectors::DetID::ITS> + ;
-#pragma link C++ class o2::itsmft::DPLAlpideParam < o2::detectors::DetID::MFT> + ;
-#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::itsmft::DPLAlpideParam < o2::detectors::DetID::ITS>> + ;
-#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::itsmft::DPLAlpideParam < o2::detectors::DetID::MFT>> + ;
-
 #pragma link C++ class o2::itsmft::GeometryTGeo;
 
 #endif

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/CTFCoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/CTFCoder.h
@@ -27,6 +27,7 @@
 #include "ITSMFTReconstruction/LookUp.h"
 #include "ITSMFTReconstruction/PixelData.h"
 #include "ITSMFTReconstruction/Clusterer.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 #include "DetectorsBase/CTFCoderBase.h"
 
@@ -39,19 +40,22 @@ namespace o2
 namespace itsmft
 {
 
+template <int N>
 class CTFCoder final : public o2::ctf::CTFCoderBase
 {
  public:
+  static constexpr o2::detectors::DetID ID{N == o2::detectors::DetID::ITS ? o2::detectors::DetID::ITS : o2::detectors::DetID::MFT};
+
   using PMatrix = std::array<std::array<bool, ClusterPattern::MaxRowSpan + 2>, ClusterPattern::MaxColSpan + 2>;
   using RowColBuff = std::vector<PixelData>;
 
-  CTFCoder(o2::ctf::CTFCoderBase::OpType op, o2::detectors::DetID det, const std::string& ctfdictOpt = "none") : o2::ctf::CTFCoderBase(op, CTF::getNBlocks(), det, 1.f, ctfdictOpt) {}
+  CTFCoder(o2::ctf::CTFCoderBase::OpType op, const std::string& ctfdictOpt = "none") : o2::ctf::CTFCoderBase(op, CTF::getNBlocks(), ID, 1.f, ctfdictOpt) {}
   ~CTFCoder() final = default;
 
   /// entropy-encode clusters to buffer with CTF
   template <typename VEC>
   o2::ctf::CTFIOSize encode(VEC& buff, const gsl::span<const ROFRecord>& rofRecVec, const gsl::span<const CompClusterExt>& cclusVec,
-                            const gsl::span<const unsigned char>& pattVec, const LookUp& clPattLookup, int strobeLength);
+                            const gsl::span<const unsigned char>& pattVec, const LookUp& clPattLookup, int layer);
 
   /// entropy decode clusters from buffer with CTF
   template <typename VROF, typename VCLUS, typename VPAT>
@@ -79,16 +83,19 @@ class CTFCoder final : public o2::ctf::CTFCoderBase
   template <typename VROF, typename VDIG>
   void decompress(const CompressedClusters& compCl, VROF& rofRecVec, VDIG& digVec, const NoiseMap* noiseMap, const LookUp& clPattLookup);
 
-  void appendToTree(TTree& tree, CTF& ec);
-  void readFromTree(TTree& tree, int entry, std::vector<ROFRecord>& rofRecVec, std::vector<CompClusterExt>& cclusVec, std::vector<unsigned char>& pattVec, const NoiseMap* noiseMap, const LookUp& clPattLookup);
+  void appendToTree(TTree& tree, CTF& ec, int id = -1);
+  void readFromTree(TTree& tree, int entry, int id, std::vector<ROFRecord>& rofRecVec, std::vector<CompClusterExt>& cclusVec, std::vector<unsigned char>& pattVec, const NoiseMap* noiseMap, const LookUp& clPattLookup);
 };
 
 /// entropy-encode clusters to buffer with CTF
+template <int N>
 template <typename VEC>
-o2::ctf::CTFIOSize CTFCoder::encode(VEC& buff, const gsl::span<const ROFRecord>& rofRecVec, const gsl::span<const CompClusterExt>& cclusVec,
-                                    const gsl::span<const unsigned char>& pattVec, const LookUp& clPattLookup, int strobeLength)
+o2::ctf::CTFIOSize CTFCoder<N>::encode(VEC& buff, const gsl::span<const ROFRecord>& rofRecVec, const gsl::span<const CompClusterExt>& cclusVec,
+                                       const gsl::span<const unsigned char>& pattVec, const LookUp& clPattLookup, int layer)
 {
   using MD = o2::ctf::Metadata::OptStore;
+  const auto& par = DPLAlpideParam<N>::Instance();
+  int strobeLength = par.supportsStaggering() ? par.roFrameLayerLengthInBC[layer] : par.roFrameLengthInBC;
   // what to do which each field: see o2::ctd::Metadata explanation
   constexpr MD optField[CTF::getNBlocks()] = {
     MD::EENCODE_OR_PACK, // BLCfirstChipROF
@@ -104,6 +111,8 @@ o2::ctf::CTFIOSize CTFCoder::encode(VEC& buff, const gsl::span<const ROFRecord>&
   };
   CompressedClusters compCl;
   compress(compCl, rofRecVec, cclusVec, pattVec, clPattLookup, strobeLength);
+  compCl.header.maxStreams = par.supportsStaggering() ? par.getNLayers() : 1;
+  compCl.header.streamID = par.supportsStaggering() ? layer : 0;
   // book output size with some margin
   auto szIni = estimateCompressedSize(compCl);
   buff.resize(szIni);
@@ -136,19 +145,26 @@ o2::ctf::CTFIOSize CTFCoder::encode(VEC& buff, const gsl::span<const ROFRecord>&
 }
 
 /// decode entropy-encoded clusters to standard compact clusters
+template <int N>
 template <typename VROF, typename VCLUS, typename VPAT>
-o2::ctf::CTFIOSize CTFCoder::decode(const CTF::base& ec, VROF& rofRecVec, VCLUS& cclusVec, VPAT& pattVec, const NoiseMap* noiseMap, const LookUp& clPattLookup)
+o2::ctf::CTFIOSize CTFCoder<N>::decode(const CTF::base& ec, VROF& rofRecVec, VCLUS& cclusVec, VPAT& pattVec, const NoiseMap* noiseMap, const LookUp& clPattLookup)
 {
   o2::ctf::CTFIOSize iosize;
   auto compCl = decodeCompressedClusters(ec, iosize);
+  const auto& par = DPLAlpideParam<N>::Instance();
+  uint32_t nLayers = par.supportsStaggering() ? par.getNLayers() : 1;
+  if (compCl.header.maxStreams != nLayers) {
+    throw std::runtime_error(fmt::format("header maxStreams={} is not the same as NStreams={} in {}staggered mode", compCl.header.maxStreams, nLayers, par.supportsStaggering() ? "" : "non-"));
+  }
   decompress(compCl, rofRecVec, cclusVec, pattVec, noiseMap, clPattLookup);
   iosize.rawIn = rofRecVec.size() * sizeof(ROFRecord) + cclusVec.size() * sizeof(CompClusterExt) + pattVec.size() * sizeof(unsigned char);
   return iosize;
 }
 
 /// decode entropy-encoded clusters to digits
+template <int N>
 template <typename VROF, typename VDIG>
-o2::ctf::CTFIOSize CTFCoder::decode(const CTF::base& ec, VROF& rofRecVec, VDIG& digVec, const NoiseMap* noiseMap, const LookUp& clPattLookup)
+o2::ctf::CTFIOSize CTFCoder<N>::decode(const CTF::base& ec, VROF& rofRecVec, VDIG& digVec, const NoiseMap* noiseMap, const LookUp& clPattLookup)
 {
   o2::ctf::CTFIOSize iosize;
   auto compCl = decodeCompressedClusters(ec, iosize);
@@ -158,8 +174,9 @@ o2::ctf::CTFIOSize CTFCoder::decode(const CTF::base& ec, VROF& rofRecVec, VDIG& 
 }
 
 /// decompress compressed clusters to standard compact clusters
+template <int N>
 template <typename VROF, typename VCLUS, typename VPAT>
-void CTFCoder::decompress(const CompressedClusters& compCl, VROF& rofRecVec, VCLUS& cclusVec, VPAT& pattVec, const NoiseMap* noiseMap, const LookUp& clPattLookup)
+void CTFCoder<N>::decompress(const CompressedClusters& compCl, VROF& rofRecVec, VCLUS& cclusVec, VPAT& pattVec, const NoiseMap* noiseMap, const LookUp& clPattLookup)
 {
   PMatrix pmat{};
   RowColBuff firedPixBuff{}, maskedPixBuff{};
@@ -343,8 +360,9 @@ void CTFCoder::decompress(const CompressedClusters& compCl, VROF& rofRecVec, VCL
 }
 
 /// decompress compressed clusters to digits
+template <int N>
 template <typename VROF, typename VDIG>
-void CTFCoder::decompress(const CompressedClusters& compCl, VROF& rofRecVec, VDIG& digVec, const NoiseMap* noiseMap, const LookUp& clPattLookup)
+void CTFCoder<N>::decompress(const CompressedClusters& compCl, VROF& rofRecVec, VDIG& digVec, const NoiseMap* noiseMap, const LookUp& clPattLookup)
 {
   rofRecVec.resize(compCl.header.nROFs);
   digVec.reserve(compCl.header.nClusters * 2);

--- a/Detectors/ITSMFT/common/reconstruction/src/CTFCoder.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/CTFCoder.cxx
@@ -21,28 +21,31 @@ using namespace o2::itsmft;
 
 ///___________________________________________________________________________________
 // Register encoded data in the tree (Fill is not called, will be done by caller)
-void CTFCoder::appendToTree(TTree& tree, CTF& ec)
+template <int N>
+void CTFCoder<N>::appendToTree(TTree& tree, CTF& ec, int id)
 {
-  ec.appendToTree(tree, mDet.getName());
+  ec.appendToTree(tree, id >= 0 ? fmt::format("{}_{}", mDet.getName(), id) : mDet.getName());
 }
 
 ///___________________________________________________________________________________
 // extract and decode data from the tree
-void CTFCoder::readFromTree(TTree& tree, int entry, std::vector<ROFRecord>& rofRecVec,
-                            std::vector<CompClusterExt>& cclusVec, std::vector<unsigned char>& pattVec, const NoiseMap* noiseMap, const LookUp& clPattLookup)
+template <int N>
+void CTFCoder<N>::readFromTree(TTree& tree, int entry, int id, std::vector<ROFRecord>& rofRecVec,
+                               std::vector<CompClusterExt>& cclusVec, std::vector<unsigned char>& pattVec, const NoiseMap* noiseMap, const LookUp& clPattLookup)
 {
   assert(entry >= 0 && entry < tree.GetEntries());
   CTF ec;
-  ec.readFromTree(tree, mDet.getName(), entry);
+  ec.readFromTree(tree, id >= 0 ? fmt::format("{}_{}", mDet.getName(), id) : mDet.getName(), entry);
   decode(ec, rofRecVec, cclusVec, pattVec, noiseMap, clPattLookup);
 }
 
 ///________________________________
-void CTFCoder::compress(CompressedClusters& cc,
-                        const gsl::span<const ROFRecord>& rofRecVec,
-                        const gsl::span<const CompClusterExt>& cclusVec,
-                        const gsl::span<const unsigned char>& pattVec,
-                        const LookUp& clPattLookup, int strobeLength)
+template <int N>
+void CTFCoder<N>::compress(CompressedClusters& cc,
+                           const gsl::span<const ROFRecord>& rofRecVec,
+                           const gsl::span<const CompClusterExt>& cclusVec,
+                           const gsl::span<const unsigned char>& pattVec,
+                           const LookUp& clPattLookup, int strobeLength)
 {
   // store in the header the orbit of 1st ROF
   cc.clear();
@@ -191,11 +194,12 @@ void CTFCoder::compress(CompressedClusters& cc,
 }
 
 ///________________________________
-void CTFCoder::createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op)
+template <int N>
+void CTFCoder<N>::createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op)
 {
   const auto ctf = CTF::getImage(bufVec.data());
   CompressedClusters cc; // just to get member types
-#define MAKECODER(part, slot) createCoder(op, std::get<rans::RenormedDenseHistogram<decltype(part)::value_type>>(ctf.getDictionary<decltype(part)::value_type>(slot, mANSVersion)), int(slot))
+#define MAKECODER(part, slot) createCoder(op, std::get<rans::RenormedDenseHistogram<typename decltype(part)::value_type>>(ctf.getDictionary<typename decltype(part)::value_type>(slot, mANSVersion)), int(slot))
   // clang-format off
   MAKECODER(cc.firstChipROF, CTF::BLCfirstChipROF);
   MAKECODER(cc.bcIncROF,     CTF::BLCbcIncROF    );
@@ -212,7 +216,8 @@ void CTFCoder::createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBa
 }
 
 ///________________________________
-size_t CTFCoder::estimateCompressedSize(const CompressedClusters& cc)
+template <int N>
+size_t CTFCoder<N>::estimateCompressedSize(const CompressedClusters& cc)
 {
   size_t sz = 0;
   // RS FIXME this is very crude estimate, instead, an empirical values should be used
@@ -234,7 +239,8 @@ size_t CTFCoder::estimateCompressedSize(const CompressedClusters& cc)
 }
 
 ///________________________________
-CompressedClusters CTFCoder::decodeCompressedClusters(const CTF::base& ec, o2::ctf::CTFIOSize& iosize)
+template <int N>
+CompressedClusters CTFCoder<N>::decodeCompressedClusters(const CTF::base& ec, o2::ctf::CTFIOSize& iosize)
 {
   CompressedClusters cc;
   cc.header = ec.getHeader();
@@ -256,3 +262,6 @@ CompressedClusters CTFCoder::decodeCompressedClusters(const CTF::base& ec, o2::c
   // clang-format on
   return cc;
 }
+
+template class CTFCoder<o2::detectors::DetID::ITS>;
+template class CTFCoder<o2::detectors::DetID::MFT>;

--- a/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/DigiParams.h
+++ b/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/DigiParams.h
@@ -19,7 +19,7 @@
 #include <algorithm>
 #include <Rtypes.h>
 #include "ITSMFTSimulation/AlpideSignalTrapezoid.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 
 ////////////////////////////////////////////////////////////
 //                                                        //

--- a/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/ClusterReaderSpec.h
+++ b/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/ClusterReaderSpec.h
@@ -23,7 +23,7 @@
 #include "DataFormatsITSMFT/CompCluster.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "DataFormatsITSMFT/ROFRecord.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 

--- a/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/ClustererSpec.h
+++ b/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/ClustererSpec.h
@@ -18,7 +18,7 @@
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
 #include "ITSMFTReconstruction/Clusterer.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 
 using namespace o2::framework;
 

--- a/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/DigitReaderSpec.h
+++ b/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/DigitReaderSpec.h
@@ -16,7 +16,7 @@
 
 #include "TFile.h"
 #include "TTree.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "DataFormatsITSMFT/Digit.h"
 #include "DataFormatsITSMFT/GBTCalibData.h"
 #include "DataFormatsITSMFT/ROFRecord.h"

--- a/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/EntropyDecoderSpec.h
+++ b/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/EntropyDecoderSpec.h
@@ -29,38 +29,38 @@ namespace o2
 namespace itsmft
 {
 
+template <int N>
 class EntropyDecoderSpec : public o2::framework::Task
 {
  public:
-  EntropyDecoderSpec(o2::header::DataOrigin orig, int verbosity, bool getDigits = false, const std::string& ctfdictOpt = "none");
+  EntropyDecoderSpec(int verbosity, bool getDigits = false, const std::string& ctfdictOpt = "none");
   ~EntropyDecoderSpec() override = default;
   void init(o2::framework::InitContext& ic) final;
   void run(o2::framework::ProcessingContext& pc) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
   void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
 
-  static auto getName(o2::header::DataOrigin orig) { return std::string{orig == o2::header::gDataOriginITS ? ITSDeviceName : MFTDeviceName}; }
+  static std::string getBinding(const std::string& name, int spec);
+  static constexpr o2::detectors::DetID ID{N == o2::detectors::DetID::ITS ? o2::detectors::DetID::ITS : o2::detectors::DetID::MFT};
+  static constexpr o2::header::DataOrigin Origin{N == o2::detectors::DetID::ITS ? o2::header::gDataOriginITS : o2::header::gDataOriginMFT};
 
  private:
   void updateTimeDependentParams(o2::framework::ProcessingContext& pc);
 
-  static constexpr std::string_view ITSDeviceName = "its-entropy-decoder";
-  static constexpr std::string_view MFTDeviceName = "mft-entropy-decoder";
-  o2::header::DataOrigin mOrigin = o2::header::gDataOriginInvalid;
-  o2::itsmft::CTFCoder mCTFCoder;
+  o2::itsmft::CTFCoder<N> mCTFCoder;
   const NoiseMap* mNoiseMap = nullptr;
   LookUp mPattIdConverter;
   bool mGetDigits{false};
   bool mMaskNoise{false};
   bool mUseClusterDictionary{true};
-  std::string mDetPrefix{};
 
   std::string mCTFDictPath{};
   TStopwatch mTimer;
 };
 
 /// create a processor spec
-framework::DataProcessorSpec getEntropyDecoderSpec(o2::header::DataOrigin orig, int verbosity, bool getDigits, unsigned int sspec, const std::string& ctfdictOpt);
+framework::DataProcessorSpec getITSEntropyDecoderSpec(int verbosity, bool getDigits, unsigned int sspec, const std::string& ctfdictOpt);
+framework::DataProcessorSpec getMFTEntropyDecoderSpec(int verbosity, bool getDigits, unsigned int sspec, const std::string& ctfdictOpt);
 
 } // namespace itsmft
 } // namespace o2

--- a/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/EntropyEncoderSpec.h
+++ b/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/EntropyEncoderSpec.h
@@ -27,10 +27,12 @@ namespace o2
 namespace itsmft
 {
 
+template <int N>
 class EntropyEncoderSpec : public o2::framework::Task
 {
+
  public:
-  EntropyEncoderSpec(o2::header::DataOrigin orig, bool selIR, const std::string& ctfdictOpt = "none");
+  EntropyEncoderSpec(bool selIR, const std::string& ctfdictOpt = "none");
   ~EntropyEncoderSpec() override = default;
   void run(o2::framework::ProcessingContext& pc) final;
   void init(o2::framework::InitContext& ic) final;
@@ -38,17 +40,20 @@ class EntropyEncoderSpec : public o2::framework::Task
   void updateTimeDependentParams(o2::framework::ProcessingContext& pc);
   void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
 
+  static std::string getBinding(const std::string& name, int spec);
+  static constexpr o2::detectors::DetID ID{N == o2::detectors::DetID::ITS ? o2::detectors::DetID::ITS : o2::detectors::DetID::MFT};
+  static constexpr o2::header::DataOrigin Origin{N == o2::detectors::DetID::ITS ? o2::header::gDataOriginITS : o2::header::gDataOriginMFT};
+
  private:
-  o2::header::DataOrigin mOrigin = o2::header::gDataOriginInvalid;
-  o2::itsmft::CTFCoder mCTFCoder;
+  o2::itsmft::CTFCoder<N> mCTFCoder;
   LookUp mPattIdConverter;
-  int mStrobeLength = 0;
   bool mSelIR = false;
   TStopwatch mTimer;
 };
 
 /// create a processor spec
-framework::DataProcessorSpec getEntropyEncoderSpec(o2::header::DataOrigin orig, bool selIR = false, const std::string& ctfdictOpt = "none");
+framework::DataProcessorSpec getITSEntropyEncoderSpec(bool selIR = false, const std::string& ctfdictOpt = "none");
+framework::DataProcessorSpec getMFTEntropyEncoderSpec(bool selIR = false, const std::string& ctfdictOpt = "none");
 
 } // namespace itsmft
 } // namespace o2

--- a/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/STFDecoderSpec.h
+++ b/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/STFDecoderSpec.h
@@ -22,7 +22,7 @@
 #include <TStopwatch.h>
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "DataFormatsITSMFT/ROFRecord.h"
 #include "ITSMFTReconstruction/ChipMappingITS.h"
 #include "ITSMFTReconstruction/ChipMappingMFT.h"

--- a/Detectors/ITSMFT/common/workflow/src/ClusterReaderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/ClusterReaderSpec.cxx
@@ -20,7 +20,7 @@
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/Logger.h"
 #include "ITSMFTWorkflow/ClusterReaderSpec.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "DataFormatsITSMFT/PhysTrigger.h"
 #include "CommonUtils/NameConf.h"
 

--- a/Detectors/ITSMFT/common/workflow/src/ClusterWriterSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/ClusterWriterSpec.cxx
@@ -18,7 +18,7 @@
 #include <format>
 
 #include "Framework/ConcreteDataMatcher.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "ITSMFTWorkflow/ClusterWriterSpec.h"
 #include "DPLUtils/MakeRootTreeWriterSpec.h"
 #include "DataFormatsITSMFT/CompCluster.h"

--- a/Detectors/ITSMFT/common/workflow/src/ClustererSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/ClustererSpec.cxx
@@ -29,7 +29,7 @@
 #include "DataFormatsParameters/GRPObject.h"
 #include "ITSMFTReconstruction/DigitPixelReader.h"
 #include "DetectorsBase/GeometryManager.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "CommonConstants/LHCConstants.h"
 #include "DetectorsCommonDataFormats/DetectorNameConf.h"
 #include "ITSMFTReconstruction/ClustererParam.h"

--- a/Detectors/ITSMFT/common/workflow/src/DigitReaderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/DigitReaderSpec.cxx
@@ -20,7 +20,7 @@
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/Logger.h"
 #include "ITSMFTWorkflow/DigitReaderSpec.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "ITSMFTReconstruction/ChipMappingITS.h"
 #include "ITSMFTReconstruction/ChipMappingMFT.h"
 #include "SimulationDataFormat/MCCompLabel.h"

--- a/Detectors/ITSMFT/common/workflow/src/DigitWriterSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/DigitWriterSpec.cxx
@@ -14,7 +14,7 @@
 #include "ITSMFTWorkflow/DigitWriterSpec.h"
 #include "Framework/ConcreteDataMatcher.h"
 #include "Framework/DataRef.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "DPLUtils/MakeRootTreeWriterSpec.h"
 #include "DataFormatsITSMFT/Digit.h"
 #include "DataFormatsITSMFT/GBTCalibData.h"

--- a/Detectors/ITSMFT/common/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/EntropyDecoderSpec.cxx
@@ -20,6 +20,7 @@
 #include "ITSMFTWorkflow/EntropyDecoderSpec.h"
 #include "ITSMFTReconstruction/ClustererParam.h"
 #include "DetectorsCommonDataFormats/DetectorNameConf.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "DataFormatsITSMFT/PhysTrigger.h"
 
 using namespace o2::framework;
@@ -28,25 +29,33 @@ namespace o2
 {
 namespace itsmft
 {
-EntropyDecoderSpec::EntropyDecoderSpec(o2::header::DataOrigin orig, int verbosity, bool getDigits, const std::string& ctfdictOpt)
-  : mOrigin(orig), mCTFCoder(o2::ctf::CTFCoderBase::OpType::Decoder, orig == o2::header::gDataOriginITS ? o2::detectors::DetID::ITS : o2::detectors::DetID::MFT, ctfdictOpt), mGetDigits(getDigits)
+
+template <int N>
+std::string EntropyDecoderSpec<N>::getBinding(const std::string& name, int spec)
 {
-  assert(orig == o2::header::gDataOriginITS || orig == o2::header::gDataOriginMFT);
-  mDetPrefix = orig == o2::header::gDataOriginITS ? "_ITS" : "_MFT";
+  return fmt::format("{}_{}", name, spec);
+}
+
+template <int N>
+EntropyDecoderSpec<N>::EntropyDecoderSpec(int verbosity, bool getDigits, const std::string& ctfdictOpt)
+  : mCTFCoder(o2::ctf::CTFCoderBase::OpType::Decoder, ctfdictOpt), mGetDigits(getDigits)
+{
   mTimer.Stop();
   mTimer.Reset();
   mCTFCoder.setVerbosity(verbosity);
-  mCTFCoder.setDictBinding(std::string("ctfdict") + mDetPrefix);
+  mCTFCoder.setDictBinding(std::string("ctfdict_") + ID.getName());
 }
 
-void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
+template <int N>
+void EntropyDecoderSpec<N>::init(o2::framework::InitContext& ic)
 {
-  mCTFCoder.init<CTF>(ic);
+  mCTFCoder.template init<CTF>(ic);
   mMaskNoise = ic.options().get<bool>("mask-noise");
   mUseClusterDictionary = !ic.options().get<bool>("ignore-cluster-dictionary");
 }
 
-void EntropyDecoderSpec::run(ProcessingContext& pc)
+template <int N>
+void EntropyDecoderSpec<N>::run(ProcessingContext& pc)
 {
   if (pc.services().get<o2::framework::TimingInfo>().globalRunNumberChanged) {
     mTimer.Reset();
@@ -54,105 +63,144 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
   o2::ctf::CTFIOSize iosize;
+  size_t ndigcl = 0, nrofs = 0;
   updateTimeDependentParams(pc);
-  auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>(std::string("ctf") + mDetPrefix);
-  // since the buff is const, we cannot use EncodedBlocks::relocate directly, instead we wrap its data to another flat object
-  //  const auto ctfImage = o2::itsmft::CTF::getImage(buff.data());
-
-  // this produces weird memory problems in unrelated devices, to be understood
-  // auto& trigs = pc.outputs().make<std::vector<o2::itsmft::PhysTrigger>>(OutputRef{"phystrig"}); // dummy output
-
-  auto& rofs = pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(OutputRef{"ROframes"});
-  if (mGetDigits) {
-    auto& digits = pc.outputs().make<std::vector<o2::itsmft::Digit>>(OutputRef{"Digits"});
-    if (buff.size()) {
-      iosize = mCTFCoder.decode(o2::itsmft::CTF::getImage(buff.data()), rofs, digits, mNoiseMap, mPattIdConverter);
+  std::string nm = ID.getName();
+  const auto& par = DPLAlpideParam<N>::Instance();
+  uint32_t nLayers = par.supportsStaggering() ? par.getNLayers() : 1;
+  for (uint32_t iLayer = 0; iLayer < nLayers; iLayer++) {
+    auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>(getBinding(nm + "CTF", iLayer));
+    // since the buff is const, we cannot use EncodedBlocks::relocate directly, instead we wrap its data to another flat object
+    // const auto ctfImage = o2::itsmft::CTF::getImage(buff.data());
+    const auto& ctf = o2::itsmft::CTF::getImage(buff.data());
+    if (ctf.getHeader().maxStreams != nLayers) {
+      LOGP(fatal, "Number of streams {} in the CTF header is not equal to NLayers {} from AlpideParam in {}staggered mode",
+           ctf.getHeader().maxStreams, nLayers, par.supportsStaggering() ? "" : "non-");
     }
-    mTimer.Stop();
-    LOG(info) << "Decoded " << digits.size() << " digits in " << rofs.size() << " RO frames, (" << iosize.asString() << ") in " << mTimer.CpuTime() - cput << " s";
-  } else {
-    auto& compcl = pc.outputs().make<std::vector<o2::itsmft::CompClusterExt>>(OutputRef{"compClusters"});
-    auto& patterns = pc.outputs().make<std::vector<unsigned char>>(OutputRef{"patterns"});
-    if (buff.size()) {
-      iosize = mCTFCoder.decode(o2::itsmft::CTF::getImage(buff.data()), rofs, compcl, patterns, mNoiseMap, mPattIdConverter);
+    // this produces weird memory problems in unrelated devices, to be understood
+    // auto& trigs = pc.outputs().make<std::vector<o2::itsmft::PhysTrigger>>(OutputRef{"phystrig"}); // dummy output
+    auto& rofs = pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(OutputRef{nm + "ROframes", iLayer});
+    if (mGetDigits) {
+      auto& digits = pc.outputs().make<std::vector<o2::itsmft::Digit>>(OutputRef{nm + "Digits", iLayer});
+      if (buff.size()) {
+        iosize += mCTFCoder.decode(ctf, rofs, digits, mNoiseMap, mPattIdConverter);
+      }
+      ndigcl += digits.size();
+      nrofs += rofs.size();
+    } else {
+      auto& compcl = pc.outputs().make<std::vector<o2::itsmft::CompClusterExt>>(OutputRef{nm + "compClusters", iLayer});
+      auto& patterns = pc.outputs().make<std::vector<unsigned char>>(OutputRef{nm + "patterns", iLayer});
+      if (buff.size()) {
+        iosize += mCTFCoder.decode(ctf, rofs, compcl, patterns, mNoiseMap, mPattIdConverter);
+      }
+      ndigcl += compcl.size();
     }
-    mTimer.Stop();
-    LOG(info) << "Decoded " << compcl.size() << " clusters in " << rofs.size() << " RO frames, (" << iosize.asString() << ") in " << mTimer.CpuTime() - cput << " s";
   }
-  pc.outputs().snapshot({"ctfrep", 0}, iosize);
+  pc.outputs().snapshot({nm + "ctfrep", 0}, iosize);
+  mTimer.Stop();
+  LOGP(info, "Decoded {} {} in {} ROFs of {} streams ({}) in {}staggerd mode in {} s", ndigcl, mGetDigits ? "digits" : "clusters",
+       nrofs, nLayers, iosize.asString(), par.supportsStaggering() ? "" : "non-", mTimer.CpuTime() - cput);
 }
 
-void EntropyDecoderSpec::endOfStream(EndOfStreamContext& ec)
+template <int N>
+void EntropyDecoderSpec<N>::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(info, "%s Entropy Decoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
-       mOrigin.as<std::string>(), mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
+  LOGP(info, "{} Entropy Decoding total timing: Cpu: {:.3e} Real: {:.3e} s in {} slots",
+       Origin.as<std::string>(), mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 
-void EntropyDecoderSpec::updateTimeDependentParams(ProcessingContext& pc)
+template <int N>
+void EntropyDecoderSpec<N>::updateTimeDependentParams(ProcessingContext& pc)
 {
+  std::string nm = ID.getName();
   if (pc.services().get<o2::framework::TimingInfo>().globalRunNumberChanged) { // this params need to be queried only once
     if (mMaskNoise) {
-      pc.inputs().get<o2::itsmft::NoiseMap*>(std::string("noise") + mDetPrefix);
+      pc.inputs().get<o2::itsmft::NoiseMap*>(nm + "noise");
     }
     if (mGetDigits || mMaskNoise) {
-      pc.inputs().get<o2::itsmft::TopologyDictionary*>(std::string("cldict") + mDetPrefix);
+      pc.inputs().get<o2::itsmft::TopologyDictionary*>(nm + "cldict");
     }
   }
+  pc.inputs().get<o2::itsmft::DPLAlpideParam<N>*>(nm + "alppar");
   mCTFCoder.updateTimeDependentParams(pc, true);
 }
 
-void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
+template <int N>
+void EntropyDecoderSpec<N>::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
 {
-  if (matcher == ConcreteDataMatcher(mOrigin, "NOISEMAP", 0)) {
+  if (matcher == ConcreteDataMatcher(Origin, "NOISEMAP", 0)) {
     mNoiseMap = (o2::itsmft::NoiseMap*)obj;
-    LOG(info) << mOrigin.as<std::string>() << " noise map updated";
+    LOG(info) << Origin.as<std::string>() << " noise map updated";
     return;
   }
-  if (matcher == ConcreteDataMatcher(mOrigin, "CLUSDICT", 0)) {
-    LOG(info) << mOrigin.as<std::string>() << " cluster dictionary updated" << (!mUseClusterDictionary ? " but its using is disabled" : "");
+  if (matcher == ConcreteDataMatcher(Origin, "CLUSDICT", 0)) {
+    LOG(info) << Origin.as<std::string>() << " cluster dictionary updated" << (!mUseClusterDictionary ? " but its using is disabled" : "");
     mPattIdConverter.setDictionary((const TopologyDictionary*)obj);
     return;
   }
-  if (mCTFCoder.finaliseCCDB<CTF>(matcher, obj)) {
+  if (matcher == ConcreteDataMatcher(Origin, "ALPIDEPARAM", 0)) {
+    LOG(info) << "Alpide param updated";
+    return;
+  }
+  if (mCTFCoder.template finaliseCCDB<CTF>(matcher, obj)) {
     return;
   }
 }
 
-DataProcessorSpec getEntropyDecoderSpec(o2::header::DataOrigin orig, int verbosity, bool getDigits, unsigned int sspec, const std::string& ctfdictOpt)
+template <int N>
+DataProcessorSpec getEntropyDecoderSpec(int verbosity, bool getDigits, unsigned int sspec, const std::string& ctfdictOpt)
 {
+  constexpr o2::header::DataOrigin Origin{N == o2::detectors::DetID::ITS ? o2::header::gDataOriginITS : o2::header::gDataOriginMFT};
+  constexpr o2::detectors::DetID ID{N == o2::detectors::DetID::ITS ? o2::detectors::DetID::ITS : o2::detectors::DetID::MFT};
+  const auto& par = DPLAlpideParam<N>::Instance();
+  uint32_t nLayers = par.supportsStaggering() ? par.getNLayers() : 1;
+
+  std::vector<InputSpec> inputs;
   std::vector<OutputSpec> outputs;
-  // this is a special dummy input which makes sense only in sync workflows
 
   // this produces weird memory problems in unrelated devices, to be understood
-  // outputs.emplace_back(OutputSpec{{"phystrig"}, orig, "PHYSTRIG", 0, Lifetime::Timeframe});
+  // outputs.emplace_back(OutputSpec{{"phystrig"}, Origin, "PHYSTRIG", 0, Lifetime::Timeframe});
+  std::string nm = ID.getName();
+  for (uint32_t iLayer = 0; iLayer < nLayers; ++iLayer) {
+    if (getDigits) {
+      outputs.emplace_back(OutputSpec{{nm + "Digits"}, Origin, "DIGITS", iLayer, Lifetime::Timeframe});
+      outputs.emplace_back(OutputSpec{{nm + "ROframes"}, Origin, "DIGITSROF", iLayer, Lifetime::Timeframe});
+    } else {
+      outputs.emplace_back(OutputSpec{{nm + "compClusters"}, Origin, "COMPCLUSTERS", iLayer, Lifetime::Timeframe});
+      outputs.emplace_back(OutputSpec{{nm + "ROframes"}, Origin, "CLUSTERSROF", iLayer, Lifetime::Timeframe});
+      outputs.emplace_back(OutputSpec{{nm + "patterns"}, Origin, "PATTERNS", iLayer, Lifetime::Timeframe});
+    }
+    inputs.emplace_back(EntropyDecoderSpec<N>::getBinding(nm + "CTF", iLayer), Origin, "CTFDATA", sspec * 100 + iLayer, Lifetime::Timeframe);
+  }
+  outputs.emplace_back(OutputSpec{{nm + "ctfrep"}, Origin, "CTFDECREP", 0, Lifetime::Timeframe});
 
-  if (getDigits) {
-    outputs.emplace_back(OutputSpec{{"Digits"}, orig, "DIGITS", 0, Lifetime::Timeframe});
-    outputs.emplace_back(OutputSpec{{"ROframes"}, orig, "DIGITSROF", 0, Lifetime::Timeframe});
-  } else {
-    outputs.emplace_back(OutputSpec{{"compClusters"}, orig, "COMPCLUSTERS", 0, Lifetime::Timeframe});
-    outputs.emplace_back(OutputSpec{{"ROframes"}, orig, "CLUSTERSROF", 0, Lifetime::Timeframe});
-    outputs.emplace_back(OutputSpec{{"patterns"}, orig, "PATTERNS", 0, Lifetime::Timeframe});
-  }
-  outputs.emplace_back(OutputSpec{{"ctfrep"}, orig, "CTFDECREP", 0, Lifetime::Timeframe});
-  std::string nm = orig == o2::header::gDataOriginITS ? "_ITS" : "_MFT";
-  std::vector<InputSpec> inputs;
-  inputs.emplace_back(std::string("ctf") + nm, orig, "CTFDATA", sspec, Lifetime::Timeframe);
-  inputs.emplace_back(std::string("noise") + nm, orig, "NOISEMAP", 0, Lifetime::Condition, ccdbParamSpec(fmt::format("{}/Calib/NoiseMap", orig.as<std::string>())));
-  inputs.emplace_back(std::string("cldict") + nm, orig, "CLUSDICT", 0, Lifetime::Condition, ccdbParamSpec(fmt::format("{}/Calib/ClusterDictionary", orig.as<std::string>())));
+  inputs.emplace_back(nm + "alppar", Origin, "ALPIDEPARAM", 0, Lifetime::Condition, ccdbParamSpec(fmt::format("{}/Config/AlpideParam", Origin.as<std::string>())));
+  inputs.emplace_back(nm + "noise", Origin, "NOISEMAP", 0, Lifetime::Condition, ccdbParamSpec(fmt::format("{}/Calib/NoiseMap", Origin.as<std::string>())));
+  inputs.emplace_back(nm + "cldict", Origin, "CLUSDICT", 0, Lifetime::Condition, ccdbParamSpec(fmt::format("{}/Calib/ClusterDictionary", Origin.as<std::string>())));
   if (ctfdictOpt.empty() || ctfdictOpt == "ccdb") {
-    inputs.emplace_back(std::string("ctfdict") + nm, orig, "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec(fmt::format("{}/Calib/CTFDictionaryTree", orig.as<std::string>())));
+    inputs.emplace_back(std::string{"ctfdict_"} + ID.getName(), Origin, "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec(fmt::format("{}/Calib/CTFDictionaryTree", Origin.as<std::string>())));
   }
-  inputs.emplace_back(std::string("trigoffset"), "CTP", "Trig_Offset", 0, Lifetime::Condition, ccdbParamSpec("CTP/Config/TriggerOffsets"));
+  inputs.emplace_back("trigoffset", "CTP", "Trig_Offset", 0, Lifetime::Condition, ccdbParamSpec("CTP/Config/TriggerOffsets"));
 
   return DataProcessorSpec{
-    EntropyDecoderSpec::getName(orig),
+    Origin == o2::header::gDataOriginITS ? "its-entropy-decoder" : "mft-entropy-decoder",
     inputs,
     outputs,
-    AlgorithmSpec{adaptFromTask<EntropyDecoderSpec>(orig, verbosity, getDigits, ctfdictOpt)},
+    AlgorithmSpec{adaptFromTask<EntropyDecoderSpec<N>>(verbosity, getDigits, ctfdictOpt)},
     Options{{"mask-noise", VariantType::Bool, false, {"apply noise mask to digits or clusters (involves reclusterization)"}},
             {"ignore-cluster-dictionary", VariantType::Bool, false, {"do not use cluster dictionary, always store explicit patterns"}},
             {"ans-version", VariantType::String, {"version of ans entropy coder implementation to use"}}}};
 }
+
+framework::DataProcessorSpec getITSEntropyDecoderSpec(int verbosity, bool getDigits, unsigned int sspec, const std::string& ctfdictOpt)
+{
+  return getEntropyDecoderSpec<o2::detectors::DetID::ITS>(verbosity, getDigits, sspec, ctfdictOpt);
+}
+
+framework::DataProcessorSpec getMFTEntropyDecoderSpec(int verbosity, bool getDigits, unsigned int sspec, const std::string& ctfdictOpt)
+{
+  return getEntropyDecoderSpec<o2::detectors::DetID::MFT>(verbosity, getDigits, sspec, ctfdictOpt);
+}
+
 } // namespace itsmft
 } // namespace o2

--- a/Detectors/ITSMFT/common/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/EntropyEncoderSpec.cxx
@@ -18,7 +18,7 @@
 #include "Framework/CCDBParamSpec.h"
 #include "DataFormatsITSMFT/CompCluster.h"
 #include "ITSMFTWorkflow/EntropyEncoderSpec.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 
 using namespace o2::framework;
@@ -27,20 +27,30 @@ namespace o2
 {
 namespace itsmft
 {
-EntropyEncoderSpec::EntropyEncoderSpec(o2::header::DataOrigin orig, bool selIR, const std::string& ctfdictOpt)
-  : mOrigin(orig), mCTFCoder(o2::ctf::CTFCoderBase::OpType::Encoder, orig == o2::header::gDataOriginITS ? o2::detectors::DetID::ITS : o2::detectors::DetID::MFT, ctfdictOpt), mSelIR(selIR)
+
+template <int N>
+std::string EntropyEncoderSpec<N>::getBinding(const std::string& name, int spec)
 {
-  assert(orig == o2::header::gDataOriginITS || orig == o2::header::gDataOriginMFT);
+  return fmt::format("{}_{}", name, spec);
+}
+
+template <int N>
+EntropyEncoderSpec<N>::EntropyEncoderSpec(bool selIR, const std::string& ctfdictOpt)
+  : mCTFCoder(o2::ctf::CTFCoderBase::OpType::Encoder, ctfdictOpt),
+    mSelIR(selIR)
+{
   mTimer.Stop();
   mTimer.Reset();
 }
 
-void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
+template <int N>
+void EntropyEncoderSpec<N>::init(o2::framework::InitContext& ic)
 {
-  mCTFCoder.init<CTF>(ic);
+  mCTFCoder.template init<CTF>(ic);
 }
 
-void EntropyEncoderSpec::run(ProcessingContext& pc)
+template <int N>
+void EntropyEncoderSpec<N>::run(ProcessingContext& pc)
 {
   if (pc.services().get<o2::framework::TimingInfo>().globalRunNumberChanged) {
     mTimer.Reset();
@@ -49,14 +59,21 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
   mTimer.Start(false);
   updateTimeDependentParams(pc);
 
-  auto compClusters = pc.inputs().get<gsl::span<o2::itsmft::CompClusterExt>>("compClusters");
-  auto pspan = pc.inputs().get<gsl::span<unsigned char>>("patterns");
-  auto rofs = pc.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("ROframes");
+  const auto& par = DPLAlpideParam<N>::Instance();
+  uint32_t nLayers = par.supportsStaggering() ? par.getNLayers() : 1;
+
   if (mSelIR) {
     mCTFCoder.setSelectedIRFrames(pc.inputs().get<gsl::span<o2::dataformats::IRFrame>>("selIRFrames"));
   }
-  auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{mOrigin, "CTFDATA", 0});
-  auto iosize = mCTFCoder.encode(buffer, rofs, compClusters, pspan, mPattIdConverter, mStrobeLength);
+  o2::ctf::CTFIOSize iosize{};
+  for (uint32_t iLayer = 0; iLayer < nLayers; iLayer++) {
+    auto compClusters = pc.inputs().get<gsl::span<o2::itsmft::CompClusterExt>>(getBinding("compClusters", iLayer));
+    auto pspan = pc.inputs().get<gsl::span<unsigned char>>(getBinding("patterns", iLayer));
+    auto rofs = pc.inputs().get<gsl::span<o2::itsmft::ROFRecord>>(getBinding("ROframes", iLayer));
+
+    auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{Origin, "CTFDATA", iLayer});
+    iosize += mCTFCoder.encode(buffer, rofs, compClusters, pspan, mPattIdConverter, iLayer);
+  }
   pc.outputs().snapshot({"ctfrep", 0}, iosize);
   if (mSelIR) {
     mCTFCoder.getIRFramesSelector().clear();
@@ -65,77 +82,90 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
   LOG(info) << iosize.asString() << " in " << mTimer.CpuTime() - cput << " s";
 }
 
-void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
+template <int N>
+void EntropyEncoderSpec<N>::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(info, "%s Entropy Encoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
-       mOrigin.as<std::string>(), mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
+  LOGP(info, "{} Entropy Encoding total timing: Cpu: {:.3e} Real: {:.3e} s in {} slots",
+       Origin.as<std::string>(), mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 
-void EntropyEncoderSpec::updateTimeDependentParams(ProcessingContext& pc)
+template <int N>
+void EntropyEncoderSpec<N>::updateTimeDependentParams(ProcessingContext& pc)
 {
   mCTFCoder.updateTimeDependentParams(pc, true);
   if (pc.services().get<o2::framework::TimingInfo>().globalRunNumberChanged) { // this params need to be queried only once
     if (mSelIR) {
       pc.inputs().get<o2::itsmft::TopologyDictionary*>("cldict");
-      if (mOrigin == o2::header::gDataOriginITS) {
-        pc.inputs().get<o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>*>("alppar");
-      } else {
-        pc.inputs().get<o2::itsmft::DPLAlpideParam<o2::detectors::DetID::MFT>*>("alppar");
-      }
     }
   }
+  pc.inputs().get<o2::itsmft::DPLAlpideParam<N>*>("alppar");
 }
 
-void EntropyEncoderSpec::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
+template <int N>
+void EntropyEncoderSpec<N>::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
 {
-  if (matcher == ConcreteDataMatcher(mOrigin, "CLUSDICT", 0)) {
-    LOG(info) << mOrigin.as<std::string>() << " cluster dictionary updated";
+  if (matcher == ConcreteDataMatcher(Origin, "CLUSDICT", 0)) {
+    LOG(info) << Origin.as<std::string>() << " cluster dictionary updated";
     mPattIdConverter.setDictionary((const TopologyDictionary*)obj);
     return;
   }
   // Note: strictly speaking, for Configurable params we don't need finaliseCCDB check, the singletons are updated at the CCDB fetcher level
-  if (matcher == ConcreteDataMatcher(mOrigin, "ALPIDEPARAM", 0)) {
+  if (matcher == ConcreteDataMatcher(Origin, "ALPIDEPARAM", 0)) {
     LOG(info) << "Alpide param updated";
-    if (mOrigin == o2::header::gDataOriginITS) {
-      const auto& par = DPLAlpideParam<o2::detectors::DetID::ITS>::Instance();
-      mStrobeLength = par.roFrameLengthInBC;
-    } else {
-      const auto& par = DPLAlpideParam<o2::detectors::DetID::MFT>::Instance();
-      mStrobeLength = par.roFrameLengthInBC;
-    }
     return;
   }
 
-  if (mCTFCoder.finaliseCCDB<CTF>(matcher, obj)) {
+  if (mCTFCoder.template finaliseCCDB<CTF>(matcher, obj)) {
     return;
   }
 }
 
-DataProcessorSpec getEntropyEncoderSpec(o2::header::DataOrigin orig, bool selIR, const std::string& ctfdictOpt)
+template <int N>
+DataProcessorSpec getEntropyEncoderSpec(bool selIR, const std::string& ctfdictOpt)
 {
+  constexpr o2::header::DataOrigin Origin{N == o2::detectors::DetID::ITS ? o2::header::gDataOriginITS : o2::header::gDataOriginMFT};
+  constexpr o2::detectors::DetID ID{N == o2::detectors::DetID::ITS ? o2::detectors::DetID::ITS : o2::detectors::DetID::MFT};
+  const auto& par = DPLAlpideParam<N>::Instance();
+  uint32_t nLayers = par.supportsStaggering() ? par.getNLayers() : 1;
+
   std::vector<InputSpec> inputs;
-  inputs.emplace_back("compClusters", orig, "COMPCLUSTERS", 0, Lifetime::Timeframe);
-  inputs.emplace_back("patterns", orig, "PATTERNS", 0, Lifetime::Timeframe);
-  inputs.emplace_back("ROframes", orig, "CLUSTERSROF", 0, Lifetime::Timeframe);
+  std::vector<OutputSpec> outputs;
+  for (uint32_t iLayer = 0; iLayer < nLayers; ++iLayer) {
+    inputs.emplace_back(EntropyEncoderSpec<N>::getBinding("compClusters", iLayer), Origin, "COMPCLUSTERS", iLayer, Lifetime::Timeframe);
+    inputs.emplace_back(EntropyEncoderSpec<N>::getBinding("patterns", iLayer), Origin, "PATTERNS", iLayer, Lifetime::Timeframe);
+    inputs.emplace_back(EntropyEncoderSpec<N>::getBinding("ROframes", iLayer), Origin, "CLUSTERSROF", iLayer, Lifetime::Timeframe);
+    outputs.emplace_back(Origin, "CTFDATA", iLayer, Lifetime::Timeframe);
+  }
   if (selIR) {
     inputs.emplace_back("selIRFrames", "CTF", "SELIRFRAMES", 0, Lifetime::Timeframe);
-    inputs.emplace_back("cldict", orig, "CLUSDICT", 0, Lifetime::Condition, ccdbParamSpec(fmt::format("{}/Calib/ClusterDictionary", orig.as<std::string>())));
-    inputs.emplace_back("alppar", orig, "ALPIDEPARAM", 0, Lifetime::Condition, ccdbParamSpec(fmt::format("{}/Config/AlpideParam", orig.as<std::string>())));
+    inputs.emplace_back("cldict", Origin, "CLUSDICT", 0, Lifetime::Condition, ccdbParamSpec(fmt::format("{}/Calib/ClusterDictionary", Origin.as<std::string>())));
   }
+  inputs.emplace_back("alppar", Origin, "ALPIDEPARAM", 0, Lifetime::Condition, ccdbParamSpec(fmt::format("{}/Config/AlpideParam", Origin.as<std::string>())));
 
   if (ctfdictOpt.empty() || ctfdictOpt == "ccdb") {
-    inputs.emplace_back("ctfdict", orig, "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec(fmt::format("{}/Calib/CTFDictionaryTree", orig.as<std::string>())));
+    inputs.emplace_back("ctfdict", Origin, "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec(fmt::format("{}/Calib/CTFDictionaryTree", Origin.as<std::string>())));
   }
+  outputs.emplace_back(OutputSpec{{"ctfrep"}, Origin, "CTFENCREP", 0, Lifetime::Timeframe});
   return DataProcessorSpec{
-    orig == o2::header::gDataOriginITS ? "its-entropy-encoder" : "mft-entropy-encoder",
+    Origin == o2::header::gDataOriginITS ? "its-entropy-encoder" : "mft-entropy-encoder",
     inputs,
-    Outputs{{orig, "CTFDATA", 0, Lifetime::Timeframe},
-            {{"ctfrep"}, orig, "CTFENCREP", 0, Lifetime::Timeframe}},
-    AlgorithmSpec{adaptFromTask<EntropyEncoderSpec>(orig, selIR, ctfdictOpt)},
+    outputs,
+    AlgorithmSpec{adaptFromTask<EntropyEncoderSpec<N>>(selIR, ctfdictOpt)},
     Options{{"irframe-margin-bwd", VariantType::UInt32, 0u, {"margin in BC to add to the IRFrame lower boundary when selection is requested"}},
             {"irframe-margin-fwd", VariantType::UInt32, 0u, {"margin in BC to add to the IRFrame upper boundary when selection is requested"}},
             {"mem-factor", VariantType::Float, 1.f, {"Memory allocation margin factor"}},
             {"ans-version", VariantType::String, {"version of ans entropy coder implementation to use"}}}};
 }
+
+framework::DataProcessorSpec getITSEntropyEncoderSpec(bool selIR, const std::string& ctfdictOpt)
+{
+  return getEntropyEncoderSpec<o2::detectors::DetID::ITS>(selIR, ctfdictOpt);
+}
+
+framework::DataProcessorSpec getMFTEntropyEncoderSpec(bool selIR, const std::string& ctfdictOpt)
+{
+  return getEntropyEncoderSpec<o2::detectors::DetID::MFT>(selIR, ctfdictOpt);
+}
+
 } // namespace itsmft
 } // namespace o2

--- a/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
@@ -29,7 +29,7 @@
 #include "ITSMFTReconstruction/GBTLink.h"
 #include "ITSMFTWorkflow/STFDecoderSpec.h"
 #include "DetectorsCommonDataFormats/DetectorNameConf.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "DataFormatsITSMFT/CompCluster.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 #include "CommonUtils/StringUtils.h"

--- a/Detectors/ITSMFT/common/workflow/src/entropy-encoder-workflow.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/entropy-encoder-workflow.cxx
@@ -41,9 +41,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
   bool selIR = cfgc.options().get<bool>("select-ir-frames");
   if (cfgc.options().get<bool>("runmft")) {
-    wf.emplace_back(o2::itsmft::getEntropyEncoderSpec("MFT", selIR, cfgc.options().get<std::string>("ctf-dict")));
+    wf.emplace_back(o2::itsmft::getMFTEntropyEncoderSpec(selIR, cfgc.options().get<std::string>("ctf-dict")));
   } else {
-    wf.emplace_back(o2::itsmft::getEntropyEncoderSpec("ITS", selIR));
+    wf.emplace_back(o2::itsmft::getITSEntropyEncoderSpec(selIR, cfgc.options().get<std::string>("ctf-dict")));
   }
   return wf;
 }

--- a/Detectors/Upgrades/ITS3/reconstruction/src/TrackingInterface.cxx
+++ b/Detectors/Upgrades/ITS3/reconstruction/src/TrackingInterface.cxx
@@ -13,7 +13,7 @@
 #include "ITS3Reconstruction/IOUtils.h"
 #include "ITSBase/GeometryTGeo.h"
 #include "ITStracking/TrackingConfigParam.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "DetectorsBase/GRPGeomHelper.h"
 #include "Framework/DeviceSpec.h"
 

--- a/Detectors/Upgrades/ITS3/workflow/src/ClustererSpec.cxx
+++ b/Detectors/Upgrades/ITS3/workflow/src/ClustererSpec.cxx
@@ -27,7 +27,7 @@
 #include "DataFormatsITSMFT/ROFRecord.h"
 #include "DataFormatsParameters/GRPObject.h"
 #include "ITSMFTReconstruction/DigitPixelReader.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "CommonConstants/LHCConstants.h"
 
 using namespace o2::framework;

--- a/Detectors/Upgrades/ITS3/workflow/src/TrackerSpec.cxx
+++ b/Detectors/Upgrades/ITS3/workflow/src/TrackerSpec.cxx
@@ -23,7 +23,7 @@
 #include "DataFormatsITSMFT/PhysTrigger.h"
 
 #include "ITStracking/TrackingConfigParam.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 
 #include "ITSBase/GeometryTGeo.h"
 #include "CommonDataFormat/IRFrame.h"

--- a/Detectors/Vertexing/include/DetectorsVertexing/PVertexer.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/PVertexer.h
@@ -31,7 +31,7 @@
 #include "DetectorsVertexing/PVertexerParams.h"
 #include "ReconstructionDataFormats/GlobalTrackID.h"
 #include "DataFormatsCalibration/MeanVertexObject.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "gsl/span"
 #include <numeric>
 #include <TTree.h>

--- a/Detectors/Vertexing/src/VertexTrackMatcher.cxx
+++ b/Detectors/Vertexing/src/VertexTrackMatcher.cxx
@@ -15,7 +15,7 @@
 
 #include "DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h"
 #include "DetectorsVertexing/VertexTrackMatcher.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include <unordered_map>
 #include <numeric>
 

--- a/Detectors/Vertexing/test/PVFromPool.C
+++ b/Detectors/Vertexing/test/PVFromPool.C
@@ -11,7 +11,7 @@
 #include "DataFormatsParameters/GRPECSObject.h"
 #include "DataFormatsParameters/GRPMagField.h"
 #include "DetectorsBase/Propagator.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "CCDB/BasicCCDBManager.h"
 #include <string>
 

--- a/EventVisualisation/Workflow/src/EveWorkflowHelper.cxx
+++ b/EventVisualisation/Workflow/src/EveWorkflowHelper.cxx
@@ -32,7 +32,7 @@
 #include "MCHTracking/TrackParam.h"
 #include "MCHTracking/TrackExtrap.h"
 #include "DataFormatsITSMFT/TrkClusRef.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "CommonDataFormat/IRFrame.h"
 #include "MFTBase/GeometryTGeo.h"
 #include "ITSBase/GeometryTGeo.h"

--- a/GPU/GPUTracking/display/render/GPUDisplayImportEvent.cxx
+++ b/GPU/GPUTracking/display/render/GPUDisplayImportEvent.cxx
@@ -31,7 +31,7 @@
 #include "TOFBase/Geo.h"
 #include "ITSBase/GeometryTGeo.h"
 #ifdef GPUCA_O2_LIB
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #endif
 
 #include <oneapi/tbb.h>

--- a/Steer/DigitizerWorkflow/src/ITS3DigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/ITS3DigitizerSpec.cxx
@@ -28,7 +28,7 @@
 #include "ITS3Simulation/Digitizer.h"
 #include "ITSMFTSimulation/DPLDigitizerParam.h"
 #include "ITS3Simulation/ITS3DPLDigitizerParam.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "ITSBase/GeometryTGeo.h"
 #include "ITS3Base/ITS3Params.h"
 #include "ITS3Align/MisalignmentManager.h"

--- a/Steer/DigitizerWorkflow/src/ITSMFTDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/ITSMFTDigitizerSpec.cxx
@@ -29,7 +29,7 @@
 #include "DataFormatsITSMFT/ROFRecord.h"
 #include "ITSMFTSimulation/Digitizer.h"
 #include "ITSMFTSimulation/DPLDigitizerParam.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "ITSBase/GeometryTGeo.h"
 #include "MFTBase/GeometryTGeo.h"
 #include <TChain.h>

--- a/Steer/DigitizerWorkflow/src/TRKDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TRKDigitizerSpec.cxx
@@ -27,7 +27,7 @@
 #include "DataFormatsITSMFT/ROFRecord.h"
 #include "TRKSimulation/Digitizer.h"
 #include "TRKSimulation/DPLDigitizerParam.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DataFormatsITSMFT/DPLAlpideParam.h"
 #include "TRKBase/GeometryTGeo.h"
 #include "TRKBase/TRKBaseParam.h"
 

--- a/doc/data/2021-02-o2_prs.json
+++ b/doc/data/2021-02-o2_prs.json
@@ -2399,7 +2399,7 @@
                 },
                 {
                   "node": {
-                    "path": "Detectors/ITSMFT/common/base/include/ITSMFTBase/DPLAlpideParam.h"
+                    "path": "Detectors/ITSMFT/common/base/include/DataFormatsITSMFT/DPLAlpideParam.h"
                   }
                 },
                 {

--- a/doc/data/2022-01-o2_prs.json
+++ b/doc/data/2022-01-o2_prs.json
@@ -3475,7 +3475,7 @@
               "edges": [
                 {
                   "node": {
-                    "path": "Detectors/ITSMFT/common/base/include/ITSMFTBase/DPLAlpideParam.h"
+                    "path": "Detectors/ITSMFT/common/base/include/DataFormatsITSMFT/DPLAlpideParam.h"
                   }
                 }
               ]


### PR DESCRIPTION
Tested as:
```
GLOSET="--shm-segment-size 12000000000 --timeframes-rate-limit 10 --timeframes-rate-limit-ipcid 0 "

#decode raw , create clusters and CTF file

o2-raw-tf-reader-workflow $GLOSET --input-data alien:///alice/data/2026/LHC26ab_ITS/569796/raw/0300/o2_rawtf_run00569796_tf00113138_epn078.tf  --onlyDet ITS  | \
o2-itsmft-stf-decoder-workflow $GLOSET | \
o2-itsmft-entropy-encoder-workflow $GLOSET --ans-version 1.0 --ctf-dict none | \
o2-ctf-writer-workflow $GLOSET --report-data-size-interval 1 --output-type ctf --min-file-size 10000000000 --max-ctf-per-file 40000 --onlyDet ITS | \
o2-its-cluster-writer-workflow $GLOSET --disable-mc  --outfile  o2clus_its_fromRaw.root -b --run | tee xx0.log

#decode CTF, create cluster file
o2-ctf-reader-workflow $GLOSET --ctf-input o2_ctf_run00569796_orbit0145075712_tf0000113138_alicers02.root --onlyDet ITS | \
o2-its-cluster-writer-workflow --disable-mc $GLOSET  --outfile  o2clus_its_fromCTF.root -b --run | tee xx1.log
```