### PR TITLE
ConfigurableParam: reject malformed container fields, drop redundant parseSet

### DIFF
--- a/Common/Utils/include/CommonUtils/ConfigurableParam.h
+++ b/Common/Utils/include/CommonUtils/ConfigurableParam.h
@@ -162,11 +162,6 @@ concept MapLike = Container<T> && requires {
 template <typename T>
 concept SequenceContainer = Container<T> && !MapLike<T>;
 
-template <typename T>
-concept HasPushBack = requires(T a, typename T::value_type v) {
-  { a.push_back(v) } -> std::same_as<void>;
-};
-
 template <typename>
 inline constexpr bool AlwaysFalse = false;
 
@@ -178,9 +173,12 @@ class ContainerParser
   {
     if constexpr (MapLike<T>) {
       return parseMap<T>(str);
-    } else if constexpr (SequenceContainer<T>) {
-      return parseSet<T>(str);
     } else if constexpr (Container<T>) {
+      // Covers vector/list/deque as well as set/unordered_set: parseSequence
+      // inserts at end(), which both sequence and associative-set containers
+      // accept. (Any non-map Container is a SequenceContainer, so the previous
+      // separate parseSet branch was unreachable and re-parsed into a temporary
+      // vector first.)
       return parseSequence<T>(str);
     } else {
       return parseScalar<T>(str);
@@ -198,7 +196,7 @@ class ContainerParser
   }
 
  private:
-  // Parse vector, list, deque, array
+  // Parse sequence and set containers (vector, list, deque, set, unordered_set)
   template <SequenceContainer SequenceT>
   static SequenceT parseSequence(const std::string& str)
   {
@@ -247,23 +245,6 @@ class ContainerParser
       }
       KeyType key = parseScalar<KeyType>(trim(kv[0]));
       result[key] = parseScalar<ValueType>(trim(kv[1]));
-    }
-    return result;
-  }
-
-  // Parse set containers
-  template <SequenceContainer SetT>
-  static SetT parseSet(const std::string& str)
-  {
-    SetT result;
-    using ValueType = typename SetT::value_type;
-    auto vec = parseSequence<std::vector<ValueType>>(str);
-    for (const auto& val : vec) {
-      if constexpr (HasPushBack<SetT>) {
-        result.push_back(val);
-      } else {
-        result.insert(val);
-      }
     }
     return result;
   }
@@ -357,17 +338,17 @@ class ContainerParser
       } else if (c == '}') {
         brace_depth--;
       } else if (c == delimiter && bracket_depth == 0 && brace_depth == 0) {
-        if (!current.empty()) {
-          tokens.push_back(current);
-          current.clear();
-        }
+        // Keep empty fields: a stray delimiter (e.g. "[1,,3]" or "key:") must
+        // surface as a parse error downstream rather than silently dropping an
+        // element. The empty-container case ("[]"/"{}") is handled by the
+        // callers before split() is ever reached.
+        tokens.push_back(current);
+        current.clear();
         continue;
       }
       current += c;
     }
-    if (!current.empty()) {
-      tokens.push_back(current);
-    }
+    tokens.push_back(current);
     return tokens;
   }
 };

--- a/Common/Utils/test/testConfigurableParam.cxx
+++ b/Common/Utils/test/testConfigurableParam.cxx
@@ -18,7 +18,12 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <cstdlib>
+#include <deque>
 #include <filesystem>
+#include <list>
+#include <set>
+#include <unordered_set>
+#include <vector>
 
 #include "CommonUtils/ConfigurableParamTest.h"
 
@@ -200,6 +205,40 @@ BOOST_AUTO_TEST_CASE(ConfigurableParam_ContainerParserMap)
   BOOST_CHECK_EQUAL(m["beta"], 0.3);
 }
 
+BOOST_AUTO_TEST_CASE(ConfigurableParam_ContainerParserSetAndSequenceTypes)
+{
+  // All non-map containers go through the single parseSequence path. Verify the
+  // set containers (which previously took a separate, doubly-parsing parseSet
+  // branch) still parse and de-duplicate correctly.
+  auto se = ContainerParser::parse<std::set<int>>("[2,3,2,3,2,5]");
+  BOOST_CHECK_EQUAL(se.size(), 3);
+  BOOST_CHECK(se == (std::set<int>{2, 3, 5}));
+
+  auto us = ContainerParser::parse<std::unordered_set<int>>("[1,2,3,3]");
+  BOOST_CHECK_EQUAL(us.size(), 3);
+  BOOST_CHECK(us.count(1) && us.count(2) && us.count(3));
+
+  auto li = ContainerParser::parse<std::list<int>>("[7,8]");
+  BOOST_CHECK(li == (std::list<int>{7, 8}));
+
+  auto dq = ContainerParser::parse<std::deque<int>>("[9,10]");
+  BOOST_CHECK(dq == (std::deque<int>{9, 10}));
+}
+
+BOOST_AUTO_TEST_CASE(ConfigurableParam_ContainerParserRejectsEmptyToken)
+{
+  // A stray delimiter must be reported, not silently swallowed: "[1,,3]" used to
+  // parse to a 2-element vector with no error, masking malformed configuration.
+  BOOST_CHECK_THROW(ContainerParser::parse<std::vector<int>>("[1,,3]"), std::exception);
+  BOOST_CHECK_THROW(ContainerParser::parse<std::vector<int>>("[1,2,]"), std::exception);
+  // ... and on the map side, an empty value/entry is rejected too.
+  BOOST_CHECK_THROW((ContainerParser::parse<std::map<int, int>>("{1:2,,3:4}")), std::exception);
+  BOOST_CHECK_THROW((ContainerParser::parse<std::map<int, int>>("{1:}")), std::exception);
+  // Well-formed input is unaffected.
+  auto v = ContainerParser::parse<std::vector<int>>("[1,2,3]");
+  BOOST_CHECK_EQUAL(v.size(), 3);
+}
+
 BOOST_AUTO_TEST_CASE(ConfigurableParam_DamerauLevenshteinDistance)
 {
   BOOST_CHECK_EQUAL(damerauLevenshteinDistance("TestParam.iValue", "TestParam.iValue"), 0);
@@ -255,5 +294,5 @@ BOOST_AUTO_TEST_CASE(ConfigurableParam_Container_FileIO_ROOT)
   for (const auto& s : set) {
     BOOST_CHECK(tp.set.contains(s));
   }
-  // std::remove(testFileName.c_str());
+  std::remove(testFileName.c_str());
 }


### PR DESCRIPTION
Stacked on top of AliceO2Group/AliceO2#15525 (`cfg/dynamic`) — this PR targets that branch, so the diff shown here is **only** the follow-up changes, not the container support itself.

Three follow-up improvements found while reviewing #15525, all confined to `ContainerParser` and its tests:

### 1. Reject malformed container fields instead of silently dropping them
`split()` discarded empty fields, so a stray delimiter was swallowed:
- `"[1,,3]"` parsed to a **2-element** vector with no error (element count silently corrupted).
- `"key:"` dropped the empty map value.

`split()` now keeps empty tokens, so they are rejected by `parseScalar` / the map-syntax check and surface as a parse error. The empty-container case (`"[]"` / `"{}"`) is still short-circuited by the callers before `split()` runs, so well-formed input is unaffected.

### 2. Remove the redundant `parseSet` branch (single-pass parsing)
Every non-map `Container` already satisfies `SequenceContainer`, so the `parseSet` dispatch branch was reached for **all** sequence and set types and re-parsed the string into a throwaway `std::vector` before copying element-by-element; the separate `else if constexpr (Container<T>)` branch was unreachable. `parseSequence` inserts at `end()`, which `std::set` / `std::unordered_set` accept just as well, so all non-map containers now share one single-pass path. The now-unused `HasPushBack` concept is removed.

### 3. Re-enable test cleanup
`ConfigurableParam_Container_FileIO_ROOT` left `test_config.root` on disk (the `std::remove` was commented out); re-enabled to restore test isolation.

### Tests
Adds regression coverage:
- set / unordered_set / list / deque parsing through the unified `parseSequence` path (incl. set de-duplication);
- rejection of empty tokens in both sequence and map parsing.

### Note on error severity (intentionally unchanged)
Container parse failures remain **non-fatal** (logged), which matches the existing scalar `setValue` behaviour (it already swallows scalar parse errors to `std::cerr`). This PR does **not** change that contract — it only stops malformed input from being silently *accepted* as a different value.

---
Verification: the changed parser logic was extracted into a standalone C++20 program and confirmed to compile (`g++ -std=c++20 -Wall -Wextra`) and behave correctly; full build + boost-test runs are left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
